### PR TITLE
Fix file association to open GPX files in LineageOS

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,17 +32,61 @@
 
                 <data android:scheme="geo" />
             </intent-filter>
+            <!--
+                Association of file types
+                =========================
+                Remarks about the ugly android:pathPattern:
+                - We are matching all files with a specific file ending.
+                This is done in an ugly way because of Android limitations.
+                Read http://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension
+                and http://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i/8599921
+                for more information.
+                Some apps will only respect these file associations in file selector to view
+                if the mimeType is not set, and other apps will only respect them if mimeType is set
+                to */*. Therefore we have two whole copies of the same thing, besides setting the mimeType.
+            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.gpx"
-                    android:scheme="file" />
+                <data android:host="*" />
+                <data android:scheme="file" />
+
+                <data android:scheme="content" />
+                <data android:mimeType="*/*" />
+
+                <data android:pathPattern=".*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="*" />
+                <data android:scheme="file" />
+
+                <data android:pathPattern=".*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.gpx" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/org/nitri/opentopo/MainActivity.java
+++ b/app/src/main/java/org/nitri/opentopo/MainActivity.java
@@ -85,6 +85,7 @@ public class MainActivity extends AppCompatActivity implements MapFragment.OnFra
                         mGeoPointFromIntent = getGeoPointDtoFromIntent(intent);
                         break;
                     case "file":
+                    case "content":
                         mGpxUri = intent.getData();
                         mGpxUriString = mGpxUri.toString();
                         Log.i(TAG, "Uri: " + mGpxUriString);


### PR DESCRIPTION
It would be great to use OpenTopoMap viewer without Google Services to open GPX files but the file association isn't working in LineageOS for me. This PR enables display locations by opening a file in the file manager or a file selector again.

It's taken mostly from <https://github.com/open-keychain/open-keychain/blob/master/OpenKeychain/src/main/AndroidManifest.xml>.