### PR TITLE
Add fine location permission check

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.java
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.java
@@ -185,7 +185,9 @@ public class MapFragment extends Fragment implements LocationListener, PopupMenu
                     mLocationViewModel.getCurrentNmea().setValue(s);
                 }
             };
-            mLocationManager.addNmeaListener(nmeaListener);
+            if (requireActivity().checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                mLocationManager.addNmeaListener(nmeaListener);
+            }
         }
     }
 


### PR DESCRIPTION
Hi, there, I've found a bug in version 1.11.5, the app is downloaded from F-Droid.
**Describe the bug**
It crashes on my 23 (Android 6.0) device when I first entered the app. The crash stack below:
```
    java.lang.RuntimeException: Unable to start activity ComponentInfo{org.nitri.opentopo/org.nitri.opentopo.MainActivity}: java.lang.SecurityException: "gps" location provider requires ACCESS_FINE_LOCATION permission.
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
        at android.app.ActivityThread.-wrap11(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
     Caused by: java.lang.SecurityException: "gps" location provider requires ACCESS_FINE_LOCATION permission.
        at android.os.Parcel.readException(Parcel.java:1620)
        at android.os.Parcel.readException(Parcel.java:1573)
        at android.location.ILocationManager$Stub$Proxy.addGpsStatusListener(ILocationManager.java:741)
        at android.location.LocationManager.addNmeaListener(LocationManager.java:1569)
        at org.nitri.opentopo.MapFragment.onCreate(MapFragment.java:188)
        at androidx.fragment.app.Fragment.performCreate(Fragment.java:2949)
        at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:475)
        at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:278)
        at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:112)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1647)
``` 

**Expected behavior**
This crash can be fixed by adding the permission check before `mLocationManager.addNmeaListener(nmeaListener)`. This API requires the `ACCESS_FINE_LOCATION` [in 23](https://developer.android.com/reference/android/location/LocationManager#addNmeaListener(android.location.GpsStatus.NmeaListener)). If there is no permission, a `SecurityException` is thrown.

@Pygmalion69 can you help me review this? thx!