### PR TITLE
Fix orientation sensor toggle

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -900,6 +900,13 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         //Log.d(TAG, "map rotation set to $mapRotation")
         mPrefs.edit().putBoolean(SettingsActivity.PREF_ROTATE, mapRotation).apply()
         if (mapRotation) {
+            val lastLocation = mLocationViewModel?.currentLocation?.value
+            if (lastLocation?.hasBearing() == true) {
+                stopOrientationSensor()
+                MapOrientation.setTargetMapOrientation(mMapView, lastLocation.bearing)
+            } else {
+                orientationSensor = orientationSensor ?: OrientationSensor(requireContext(), mMapView)
+            }
             Toast.makeText(requireContext(), R.string.rotation_on, Toast.LENGTH_SHORT).show()
         } else {
             stopOrientationSensor()


### PR DESCRIPTION
## Summary
- start orientation sensor immediately when map rotation is toggled

## Testing
- `./gradlew test --continue --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68596d5f5c248327b4607cd0a47ed38c