### PR TITLE
Fix cache size parsing logic

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/CacheSettingsFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/CacheSettingsFragment.kt
@@ -54,10 +54,10 @@ class CacheSettingsFragment : DialogFragment() {
                 val newExternalStorage = swExternalStorage.isChecked
                 val newTileCache = etTileCache.text.toString()
                 val newCacheSizeText = etCacheSize.text.toString()
-                val newCacheSize = try {
-                    newCacheSizeText.toInt()
-                } catch (e: NumberFormatException) {
-                    Log.e(TAG, "Invalid cache size: $newCacheSizeText", e)
+                val newCacheSize = newCacheSizeText.toIntOrNull() ?: -1
+
+                if (newCacheSize == -1) {
+                    Log.e(TAG, "Invalid cache size: $newCacheSizeText")
                 }
 
                 if (newCacheSize > 0) {


### PR DESCRIPTION
## Summary
- parse the cache size text using `toIntOrNull` and log invalid entries when detected
- ensure cache preferences are only updated when the cache size is a positive value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9a707bb083279ba02172fc6f78ed