### PR TITLE
Fix stray quote in delete confirmation prompt

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="confirm_delete">Confirm Delete</string>
-    <string name="prompt_confirm_delete">Are you sure you want to delete this item?"</string>
+    <string name="prompt_confirm_delete">Are you sure you want to delete this item?</string>
 
     <string name="settings">Settings</string>
     <string name="screen_header">Screen</string>


### PR DESCRIPTION
## Summary
- remove the trailing double quote from the delete confirmation prompt string resource so the dialog text displays correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa251214e48327bc65764b76898635