### PR TITLE
Fix GPX detail totals for multi-track files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Basic routing with the [ORS Android Client](https://github.com/Pygmalion69/ors-a
     height="80"/></a>
 
 (FOSS, no ads.)
+
+## UI Verification
+
+To confirm that multi-track GPX files report the combined distance correctly:
+
+1. Copy [`test-data/multi_track_sample.gpx`](test-data/multi_track_sample.gpx) to your device.
+2. Open OpenTopoMapViewer and import the sample GPX.
+3. Open the GPX details screen.
+4. Verify that the total distance displays approximately **2.22 km**, which reflects the sum of both tracks in the sample file.

--- a/app/src/main/java/org/nitri/opentopo/GpxDetailFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/GpxDetailFragment.kt
@@ -94,8 +94,13 @@ class GpxDetailFragment : Fragment(), WayPointListAdapter.OnItemClickListener,
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         mGpxViewModel = ViewModelProvider(requireActivity())[GpxViewModel::class.java]
+        resetTrackDistanceData()
         mGpxViewModel.gpx?.tracks?.forEach {
             buildTrackDistanceLine(it)
+        }
+        if (!hasElevationData) {
+            minElevation = 0.0
+            maxElevation = 0.0
         }
         /* if (getActivity() != null) {
             regularTypeface = Typeface.createFromAsset(getActivity().getAssets(), "OpenSans-Regular.ttf");
@@ -149,13 +154,7 @@ class GpxDetailFragment : Fragment(), WayPointListAdapter.OnItemClickListener,
     }
 
     private fun buildTrackDistanceLine(track: Track) {
-        trackDistancePoints = ArrayList()
-        totalDistance = 0.0
-        hasElevationData = false
         var prevTrackPoint: TrackPoint? = null
-
-        minElevation = Double.MAX_VALUE
-        maxElevation = Double.MIN_VALUE
 
         track.trackSegments?.forEach { segment ->
             if (trackDistancePoints.isNotEmpty()) {
@@ -182,10 +181,14 @@ class GpxDetailFragment : Fragment(), WayPointListAdapter.OnItemClickListener,
             }
         }
 
-        if (!hasElevationData) {
-            minElevation = 0.0
-            maxElevation = 0.0
-        }
+    }
+
+    private fun resetTrackDistanceData() {
+        trackDistancePoints = ArrayList()
+        totalDistance = 0.0
+        hasElevationData = false
+        minElevation = Double.MAX_VALUE
+        maxElevation = Double.MIN_VALUE
     }
 
 

--- a/test-data/multi_track_sample.gpx
+++ b/test-data/multi_track_sample.gpx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="OpenTopoMapViewer Tests" xmlns="http://www.topografix.com/GPX/1/1">
+  <metadata>
+    <name>Multi-track sample</name>
+    <desc>Two short tracks used to verify aggregated distances.</desc>
+  </metadata>
+  <trk>
+    <name>Sample Track 1</name>
+    <trkseg>
+      <trkpt lat="0.0" lon="0.0">
+        <ele>10</ele>
+      </trkpt>
+      <trkpt lat="0.0" lon="0.01">
+        <ele>12</ele>
+      </trkpt>
+    </trkseg>
+  </trk>
+  <trk>
+    <name>Sample Track 2</name>
+    <trkseg>
+      <trkpt lat="0.0" lon="0.0">
+        <ele>8</ele>
+      </trkpt>
+      <trkpt lat="0.01" lon="0.0">
+        <ele>15</ele>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
## Summary
- ensure GPX detail aggregation persists cumulative distance/elevation across all tracks
- add a reusable multi-track GPX sample for verification and document manual steps to confirm totals

------
https://chatgpt.com/codex/tasks/task_e_68fa471548a083278778d005fc6fbea6