### PR TITLE
Fix KDoc for Utils area helper

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/util/Utils.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/Utils.kt
@@ -56,11 +56,11 @@ object Utils {
 
 
     /**
-     * Get geo points bounds
+     * Get geo points bounds.
      *
-     * @param points List<GeoPoint>
-     * @return BoundingBox
-    </GeoPoint> */
+     * @param points list of geo points used to calculate the bounds.
+     * @return bounding box containing all provided geo points.
+     */
     private fun area(points: List<GeoPoint?>): BoundingBox {
         var north = Double.MIN_VALUE
         var south = Double.MAX_VALUE


### PR DESCRIPTION
## Summary
- correct the KDoc for Utils.area(List<GeoPoint?>) to remove stray HTML and use valid tags

## Testing
- ./gradlew dokkaHtml

------
https://chatgpt.com/codex/tasks/task_e_68fa4996f27c8327b7ad850f6cb19eb6