### PR TITLE
Add antipodal point unit test for distance calculator

### DIFF
--- a/app/src/test/java/org/nitri/opentopo/DistanceCalculatorTest.kt
+++ b/app/src/test/java/org/nitri/opentopo/DistanceCalculatorTest.kt
@@ -46,6 +46,14 @@ class DistanceCalculatorTest {
     }
 
     private fun createPoint(latitude: Double, longitude: Double): Point {
+        instantiateViaConstructors(latitude, longitude)?.let { return it }
+        instantiateViaUnsafe(latitude, longitude)?.let { return it }
+
+        val constructors = Point::class.java.declaredConstructors
+        error("Unable to instantiate Point via reflection. Constructors: ${constructors.joinToString { it.toGenericString() }}")
+    }
+
+    private fun instantiateViaConstructors(latitude: Double, longitude: Double): Point? {
         val constructors = Point::class.java.declaredConstructors
 
         for (constructor in constructors) {
@@ -58,19 +66,23 @@ class DistanceCalculatorTest {
             val arguments = Array<Any?>(parameterTypes.size) { index ->
                 val parameterType = parameterTypes[index]
                 when {
-                    !latAssigned && parameterType.isLatitudeLongitudeParameter() -> {
+                    parameterType.isLatitudeLongitudeParameter() && !latAssigned -> {
                         latAssigned = true
                         latitude
                     }
-                    !lonAssigned && parameterType.isLatitudeLongitudeParameter() -> {
+                    parameterType.isLatitudeLongitudeParameter() && !lonAssigned -> {
                         lonAssigned = true
                         longitude
                     }
+                    parameterType.isPointBuilder() -> parameterType.instantiateBuilder(latitude, longitude)
                     else -> parameterType.defaultValue()
                 }
             }
 
-            if (latAssigned && lonAssigned) {
+            val hasAllCoordinates = (latAssigned && lonAssigned) ||
+                arguments.any { argument -> argument?.isBuilderWithCoordinates() == true }
+
+            if (hasAllCoordinates) {
                 try {
                     val instance = constructor.newInstance(*arguments)
                     if (instance is Point && instance.latitude == latitude && instance.longitude == longitude) {
@@ -82,11 +94,108 @@ class DistanceCalculatorTest {
             }
         }
 
-        error("Unable to instantiate Point via reflection. Constructors: ${constructors.joinToString { it.toGenericString() }}")
+        return null
+    }
+
+    private fun instantiateViaUnsafe(latitude: Double, longitude: Double): Point? {
+        return try {
+            val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+            unsafeField.isAccessible = true
+            val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+            val instance = unsafe.allocateInstance(Point::class.java) as Point
+            val latitudeAssigned = instance.assignCoordinate(latitude, listOf("lat", "latitude"))
+            val longitudeAssigned = instance.assignCoordinate(longitude, listOf("lon", "lng", "long", "longitude"))
+            if (latitudeAssigned && longitudeAssigned) {
+                instance
+            } else {
+                null
+            }
+        } catch (ignored: ReflectiveOperationException) {
+            null
+        }
     }
 
     private fun Class<*>.isLatitudeLongitudeParameter(): Boolean {
-        return this == java.lang.Double.TYPE || this == java.lang.Double::class.java
+        return this == java.lang.Double.TYPE ||
+            this == java.lang.Double::class.java ||
+            this == java.lang.Float.TYPE ||
+            this == java.lang.Float::class.java
+    }
+
+    private fun Class<*>.isPointBuilder(): Boolean {
+        return enclosingClass == Point::class.java && simpleName.contains("Builder", ignoreCase = true)
+    }
+
+    private fun Class<*>.instantiateBuilder(latitude: Double, longitude: Double): Any? {
+        for (constructor in declaredConstructors.sortedBy { it.parameterCount }) {
+            constructor.isAccessible = true
+            val args = Array(constructor.parameterCount) { index ->
+                constructor.parameterTypes[index].defaultValue()
+            }
+
+            try {
+                val builder = constructor.newInstance(*args)
+                val latAssigned = builder.assignCoordinate(latitude, listOf("lat", "latitude"))
+                val lonAssigned = builder.assignCoordinate(longitude, listOf("lon", "lng", "long", "longitude"))
+                if (latAssigned && lonAssigned) {
+                    return builder
+                }
+            } catch (ignored: ReflectiveOperationException) {
+                // try next constructor
+            }
+        }
+
+        return null
+    }
+
+    private fun Any.assignCoordinate(value: Double, keywords: List<String>): Boolean {
+        val targetClass = this::class.java
+        val setter = targetClass.declaredMethods.firstOrNull { method ->
+            method.parameterTypes.size == 1 &&
+                method.parameterTypes[0].isLatitudeLongitudeParameter() &&
+                keywords.any { keyword -> method.name.contains(keyword, ignoreCase = true) }
+        }
+
+        if (setter != null) {
+            setter.isAccessible = true
+            val parameterType = setter.parameterTypes[0]
+            setter.invoke(this, convertCoordinate(value, parameterType))
+            return true
+        }
+
+        val field = targetClass.declaredFields.firstOrNull { field ->
+            field.type.isLatitudeLongitudeParameter() &&
+                keywords.any { keyword -> field.name.contains(keyword, ignoreCase = true) }
+        }
+
+        if (field != null) {
+            field.isAccessible = true
+            when (field.type) {
+                java.lang.Double.TYPE, java.lang.Double::class.java -> field.setDouble(this, value)
+                java.lang.Float.TYPE, java.lang.Float::class.java -> field.setFloat(this, value.toFloat())
+                else -> field.set(this, convertCoordinate(value, field.type))
+            }
+            return true
+        }
+
+        return false
+    }
+
+    private fun Any.isBuilderWithCoordinates(): Boolean {
+        val clazz = this::class.java
+        val hasLat = clazz.declaredFields.any { field ->
+            field.type.isLatitudeLongitudeParameter() && field.name.contains("lat", ignoreCase = true)
+        }
+        val hasLon = clazz.declaredFields.any { field ->
+            field.type.isLatitudeLongitudeParameter() &&
+                (field.name.contains("lon", ignoreCase = true) || field.name.contains("long", ignoreCase = true))
+        }
+        return hasLat && hasLon
+    }
+
+    private fun convertCoordinate(value: Double, parameterType: Class<*>): Any = when (parameterType) {
+        java.lang.Float.TYPE, java.lang.Float::class.java -> value.toFloat()
+        else -> value
     }
 
     private fun Class<*>.defaultValue(): Any? = when (this) {


### PR DESCRIPTION
## Summary
- extend the distance calculator tests to cover the Point-based overload
- add an antipodal scenario to validate cross-hemisphere calculations with tolerance
- introduce a reflective helper to instantiate library Point objects for testing

## Testing
- ./gradlew test *(fails: Failed to find Build Tools revision 35.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4af147e48327b324cb591467b88f