### PR TITLE
Enhance About dialog with external links

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -873,6 +873,24 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 getString(R.string.app_author)
             )
 
+            val productPageTextView = dialogView.findViewById<TextView>(R.id.productPage)
+            productPageTextView.movementMethod = LinkMovementMethod.getInstance()
+            productPageTextView.text = Utils.fromHtml(
+                getString(R.string.app_product_page)
+            )
+
+            val openTopoMapInfoTextView = dialogView.findViewById<TextView>(R.id.openTopoMapInfo)
+            openTopoMapInfoTextView.movementMethod = LinkMovementMethod.getInstance()
+            openTopoMapInfoTextView.text = Utils.fromHtml(
+                getString(R.string.about_open_topo_map)
+            )
+
+            val waymarkedTrailsInfoTextView = dialogView.findViewById<TextView>(R.id.waymarkedTrailsInfo)
+            waymarkedTrailsInfoTextView.movementMethod = LinkMovementMethod.getInstance()
+            waymarkedTrailsInfoTextView.text = Utils.fromHtml(
+                getString(R.string.about_waymarked_trails)
+            )
+
             val dialog = AlertDialog.Builder(it)
                 .setTitle(Utils.getAppName(it))
                 .setView(dialogView)

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -868,28 +868,16 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             versionTextView.text = getString(R.string.app_version, Utils.getAppVersion(it))
 
             val authorTextView = dialogView.findViewById<TextView>(R.id.authorName)
-            authorTextView.movementMethod = LinkMovementMethod.getInstance()
-            authorTextView.text = Utils.fromHtml(
-                getString(R.string.app_author)
-            )
+            authorTextView.setHtmlText(getString(R.string.app_author))
 
             val productPageTextView = dialogView.findViewById<TextView>(R.id.productPage)
-            productPageTextView.movementMethod = LinkMovementMethod.getInstance()
-            productPageTextView.text = Utils.fromHtml(
-                getString(R.string.app_product_page)
-            )
+            productPageTextView.setHtmlText(getString(R.string.app_product_page))
 
             val openTopoMapInfoTextView = dialogView.findViewById<TextView>(R.id.openTopoMapInfo)
-            openTopoMapInfoTextView.movementMethod = LinkMovementMethod.getInstance()
-            openTopoMapInfoTextView.text = Utils.fromHtml(
-                getString(R.string.about_open_topo_map)
-            )
+            openTopoMapInfoTextView.setHtmlText(getString(R.string.about_open_topo_map))
 
             val waymarkedTrailsInfoTextView = dialogView.findViewById<TextView>(R.id.waymarkedTrailsInfo)
-            waymarkedTrailsInfoTextView.movementMethod = LinkMovementMethod.getInstance()
-            waymarkedTrailsInfoTextView.text = Utils.fromHtml(
-                getString(R.string.about_waymarked_trails)
-            )
+            waymarkedTrailsInfoTextView.setHtmlText(getString(R.string.about_waymarked_trails))
 
             val dialog = AlertDialog.Builder(it)
                 .setTitle(Utils.getAppName(it))
@@ -899,6 +887,11 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
             dialog.show()
         }
+    }
+
+    private fun TextView.setHtmlText(htmlText: String) {
+        movementMethod = LinkMovementMethod.getInstance()
+        text = Utils.fromHtml(htmlText)
     }
 
     /**

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -19,4 +19,25 @@
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
         tools:text="By Author Name" />
+
+    <TextView
+        android:id="@+id/productPage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        tools:text="Product page" />
+
+    <TextView
+        android:id="@+id/openTopoMapInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        tools:text="OpenTopoMap info" />
+
+    <TextView
+        android:id="@+id/waymarkedTrailsInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        tools:text="Waymarked Trails info" />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -10,34 +10,34 @@
         android:id="@+id/appVersion"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp"
+        android:layout_marginTop="8dp"
         tools:text="Version 1.0" />
 
     <TextView
         android:id="@+id/authorName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp"
+        android:layout_marginTop="8dp"
         tools:text="By Author Name" />
 
     <TextView
         android:id="@+id/productPage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="16dp"
+        android:layout_marginTop="16dp"
         tools:text="Product page" />
 
     <TextView
         android:id="@+id/openTopoMapInfo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="16dp"
+        android:layout_marginTop="16dp"
         tools:text="OpenTopoMap info" />
 
     <TextView
         android:id="@+id/waymarkedTrailsInfo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp"
+        android:layout_marginTop="8dp"
         tools:text="Waymarked Trails info" />
 </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,6 +58,9 @@
     <string name="about">Über</string>
     <string name="app_version">Version %1$s</string>
     <string name="app_author">Von &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Produktseite: &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Grundkarte von &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Streckenkarten von &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; von Lonvia.</string>
 
     <string name="default_marker_name">Markierung %1$d</string>
     <string name="edit_marker">Markierung bearbeiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,6 +58,9 @@
     <string name="about">Acerca de</string>
     <string name="app_version">Versión %1$s</string>
     <string name="app_author">Por &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Página del producto: &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Mapa base de &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Capas de rutas de &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
 
     <string name="default_marker_name">Marcador %1$d</string>
     <string name="edit_marker">Editar marcador</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,6 +58,9 @@
     <string name="about">À propos</string>
     <string name="app_version">Version %1$s</string>
     <string name="app_author">Par &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Page produit : &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Fond de carte par &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Calques d&#39;itinéraires par &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
 
     <string name="default_marker_name">Marqueur %1$d</string>
     <string name="edit_marker">Modifier le marqueur</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,7 +60,7 @@
     <string name="app_author">Par &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="app_product_page">Page produit : &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
     <string name="about_open_topo_map">Fond de carte par &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
-    <string name="about_waymarked_trails">Calques d&#39;itinéraires par &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
+    <string name="about_waymarked_trails">Calques d\'itinéraires par &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
 
     <string name="default_marker_name">Marqueur %1$d</string>
     <string name="edit_marker">Modifier le marqueur</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -58,6 +58,9 @@
     <string name="about">Info</string>
     <string name="app_version">Versione %1$s</string>
     <string name="app_author">Di &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Pagina del prodotto: &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Mappa di base di &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Sovrapposizioni dei sentieri di &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; di Lonvia.</string>
 
     <string name="default_marker_name">Segnaposto %1$d</string>
     <string name="edit_marker">Modifica Segnaposto</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -58,6 +58,9 @@
     <string name="about">Over</string>
     <string name="app_version">Versie %1$s</string>
     <string name="app_author">Door &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Productpagina: &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Basiskaart door &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Route-overlays door &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; van Lonvia.</string>
 
     <string name="default_marker_name">Markering %1$d</string>
     <string name="edit_marker">Markering bewerken</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,9 @@
     <string name="about">About</string>
     <string name="app_version">Version %1$s</string>
     <string name="app_author">By &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
+    <string name="app_product_page">Product page: &lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
+    <string name="about_open_topo_map">Base map by &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
+    <string name="about_waymarked_trails">Trail overlays by &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; by Lonvia.</string>
 
     <string name="default_marker_name">Marker %1$d</string>
     <string name="edit_marker">Edit Marker</string>


### PR DESCRIPTION
## Summary
- add a product page link to the About dialog
- highlight OpenTopoMap and Waymarked Trails resources with direct links

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe498009488327a6eb2650d56c5f07