### PR TITLE
Add OpenTopoMap-R tile source option

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="layers">Ebenen</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Wandern</string>
     <string name="lonvia_cycling">Lonvia Radfahren</string>
@@ -38,6 +39,7 @@
     <string name="map_rotation">Kartenrotation</string>
     <string name="tap_compass_to_rotate">Tippen Sie auf den Kompass, um die Karte zu drehen</string>
     <string name="max_zoom_level">Maximale Zoomstufe</string>
+    <string name="open_topo_map_source">OpenTopoMap-Kachelquelle</string>
 
     <string name="nearby">In der Nähe</string>
 
@@ -61,6 +63,7 @@
     <string name="app_author">Von &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="about_open_topo_map">Grundkarte von &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Streckenkarten von &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; von Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Markierung %1$d</string>
     <string name="edit_marker">Markierung bearbeiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="layers">Capas</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Senderismo</string>
     <string name="lonvia_cycling">Lonvia Ciclismo</string>
@@ -38,6 +39,7 @@
     <string name="map_rotation">Rotación del mapa</string>
     <string name="tap_compass_to_rotate">Toca la brújula para girar el mapa</string>
     <string name="max_zoom_level">Nivel máximo de zoom</string>
+    <string name="open_topo_map_source">Fuente de teselas de OpenTopoMap</string>
 
     <string name="nearby">Cerca</string>
 
@@ -61,6 +63,7 @@
     <string name="app_author">Por &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="about_open_topo_map">Mapa base de &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Capas de rutas de &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Marcador %1$d</string>
     <string name="edit_marker">Editar marcador</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="layers">Couches</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Randonnée</string>
     <string name="lonvia_cycling">Lonvia Vélo</string>
@@ -38,6 +39,7 @@
     <string name="map_rotation">Rotation de la carte</string>
     <string name="tap_compass_to_rotate">Appuyez sur la boussole pour faire pivoter la carte</string>
     <string name="max_zoom_level">Niveau de zoom maximal</string>
+    <string name="open_topo_map_source">Source des tuiles OpenTopoMap</string>
 
     <string name="nearby">À proximité</string>
 
@@ -61,6 +63,7 @@
     <string name="app_author">Par &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="about_open_topo_map">Fond de carte par &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Calques d\'itinéraires par &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; de Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Marqueur %1$d</string>
     <string name="edit_marker">Modifier le marqueur</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="layers">Sovrapposizioni</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Escursionismo</string>
     <string name="lonvia_cycling">Lonvia Ciclismo</string>
@@ -38,6 +39,7 @@
     <string name="map_rotation">Rotazione mappa</string>
     <string name="tap_compass_to_rotate">Tap sulla bussola per ruotare la mappa</string>
     <string name="max_zoom_level">Livello di zoom massimo</string>
+    <string name="open_topo_map_source">Sorgente tile OpenTopoMap</string>
 
     <string name="nearby">Nei paraggi</string>
 
@@ -61,6 +63,7 @@
     <string name="app_author">Di &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="about_open_topo_map">Mappa di base di &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Sovrapposizioni dei sentieri di &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; di Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Segnaposto %1$d</string>
     <string name="edit_marker">Modifica Segnaposto</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="layers">Lagen</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Wandelen</string>
     <string name="lonvia_cycling">Lonvia Fietsen</string>
@@ -38,6 +39,7 @@
     <string name="map_rotation">Kaartrotatie</string>
     <string name="tap_compass_to_rotate">Tik op het kompas om de kaart te draaien</string>
     <string name="max_zoom_level">Maximaal zoomniveau</string>
+    <string name="open_topo_map_source">OpenTopoMap-tegelbron</string>
 
     <string name="nearby">In de buurt</string>
 
@@ -61,6 +63,7 @@
     <string name="app_author">Door &lt;a href="http://www.sergehelfrich.eu/"&gt;Serge Helfrich&lt;/a&gt;</string>
     <string name="about_open_topo_map">Basiskaart door &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Route-overlays door &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; van Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Markering %1$d</string>
     <string name="edit_marker">Markering bewerken</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -13,4 +13,12 @@
         <item>16</item>
         <item>17</item>
     </string-array>
+    <string-array name="open_topo_map_source_entries">
+        <item>@string/open_topo_map</item>
+        <item>@string/open_topo_map_r</item>
+    </string-array>
+    <string-array name="open_topo_map_source_values">
+        <item>opentopomap</item>
+        <item>opentopomap_r</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
 
     <string name="layers">Layers</string>
     <string name="open_topo_map">OpenTopoMap</string>
+    <string name="open_topo_map_r">OpenTopoMap-R</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Hiking</string>
     <string name="lonvia_cycling">Lonvia Cycling</string>
@@ -40,6 +41,7 @@
     <string name="map_rotation">Map rotation</string>
     <string name="tap_compass_to_rotate">Tap compass to rotate map</string>
     <string name="max_zoom_level">Maximum zoom level</string>
+    <string name="open_topo_map_source">OpenTopoMap tile source</string>
 
     <string name="nearby">Nearby</string>
 
@@ -64,6 +66,7 @@
     <string name="app_product_page" translatable="false">&lt;a href="https://opentopomap.sergehelfrich.eu/"&gt;opentopomap.sergehelfrich.eu&lt;/a&gt;</string>
     <string name="about_open_topo_map">Base map by &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Trail overlays by &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; by Lonvia.</string>
+    <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
 
     <string name="default_marker_name">Marker %1$d</string>
     <string name="edit_marker">Edit Marker</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,6 +24,14 @@
             app:defaultValue="17"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:key="open_topo_map_source"
+            app:title="@string/open_topo_map_source"
+            app:entries="@array/open_topo_map_source_entries"
+            app:entryValues="@array/open_topo_map_source_values"
+            app:defaultValue="opentopomap"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/cache_header">


### PR DESCRIPTION
### Motivation
- Provide support for the OpenTopoMap-R tile source (openmaps.fr) as an alternative to the existing OpenTopoMap tiles.
- Allow the user to choose the OpenTopoMap tile source via the app Settings so the map base layer can use either source.

### Description
- Added a new `ListPreference` `open_topo_map_source` and corresponding arrays `open_topo_map_source_entries` / `open_topo_map_source_values` in `preferences.xml` and `arrays.xml` to expose the choice in Settings.
- Introduced localized strings including `open_topo_map_r` and `open_topo_map_r_copyright` across resources so the new option and copyright are shown in multiple locales.
- Wired the preference into `MapFragment` by adding `openTopoMapSource`, `readOpenTopoMapSource()`, and `resolveOpenTopoMapTileSource()`; `setBaseMap()` now uses the resolver and `resolveOpenTopoMapTileSource()` returns an `XYTileSource` pointing to `https://tile.openmaps.fr/opentopomap/` when `opentopomap_r` is selected.
- On resume the fragment reads the selected `PREF_BASE_MAP` and `PREF_OPEN_TOPO_MAP_SOURCE` and updates the tile source if the user changed the preference.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566840288883279ead0539006726f2)