### PR TITLE
Recalculate routes after waypoint drags

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -384,7 +384,10 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         markerViewModel.markers.observe(viewLifecycleOwner) { markers ->
             overlayHelper?.setMarkers(markers, object : OverlayHelper.MarkerInteractionListener {
                 override fun onMarkerMoved(markerModel: MarkerModel) {
-                    //NOP
+                    markerViewModel.updateMarker(markerModel)
+                    if (markerModel.routeWaypoint) {
+                        calculateRoute()
+                    }
                 }
 
                 override fun onMarkerClicked(markerModel: MarkerModel) {

--- a/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
+++ b/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
@@ -75,6 +75,7 @@ class OverlayHelper(private val mContext: Context, private val mMapView: MapView
                 val markerModel = it.relatedObject as MarkerModel
                 markerModel.latitude = it.position.latitude
                 markerModel.longitude = it.position.longitude
+                markerInteractionListener.onMarkerMoved(markerModel)
             }
         }
 


### PR DESCRIPTION
### Motivation

- Dragging a marker previously updated its position but did not notify listeners to persist the change. 
- When a marker that is a routing waypoint is dragged the displayed ORS-calculated route must be recalculated to reflect the new location. 
- Bring drag behavior in line with add/remove waypoint flows which already trigger route recalculation.

### Description

- Notify the marker interaction listener from `OverlayHelper.onMarkerDragEnd` after updating the `MarkerModel` coordinates. 
- Implement `onMarkerMoved` in `MapFragment` to persist the moved marker via `markerViewModel.updateMarker(markerModel)` and call `calculateRoute()` when `markerModel.routeWaypoint` is true. 
- Modified files: `app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt` and `app/src/main/java/org/nitri/opentopo/MapFragment.kt`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957d677e76c8327924e2ffce0182d19)