### PR TITLE
Sync rotation preference and reliably reset map to north

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -601,6 +601,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             openTopoMapSource = preferredOpenTopoMapSource
             setBaseMap()
         }
+        syncMapRotationPreference()
         if (followEnabled) {
             locationOverlay?.enableFollowLocation()
             mapHandler.removeCallbacks(centerMapRunnable)
@@ -650,6 +651,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         } catch (ex: Exception) {
             ex.printStackTrace()
         }
+        stopOrientationSensor()
         mapHandler.removeCallbacks(centerMapRunnable)
         compassOverlay?.disableCompass()
         locationOverlay?.disableFollowLocation()
@@ -994,6 +996,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 return@runOnUiThread
             }
 
+            syncMapRotationPreference()
             locationViewModel?.currentLocation?.postValue(location)
             if (mapRotation) {
                 if (location.hasBearing()) {
@@ -1008,8 +1011,16 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 }
             } else {
                 stopOrientationSensor()
-                if (mapView.mapOrientation != 0f) MapOrientation.reset(mapView)
+                MapOrientation.reset(mapView)
             }
+        }
+    }
+
+    private fun syncMapRotationPreference() {
+        mapRotation = sharedPreferences.getBoolean(SettingsActivity.PREF_ROTATE, false)
+        if (!mapRotation) {
+            stopOrientationSensor()
+            MapOrientation.reset(mapView)
         }
     }
 

--- a/app/src/main/java/org/nitri/opentopo/util/MapOrientation.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/MapOrientation.kt
@@ -104,6 +104,8 @@ object MapOrientation {
         // Log.d(TAG, "reset orientation")
         debounceJob?.cancel()
         animationJob?.cancel()
+        mapOrientation = 0f
+        previousMapOrientation = 0f
         targetMapOrientation = 0f
         mapView.mapOrientation = 0f
     }


### PR DESCRIPTION
### Motivation

- Fix cases where the map still rotated even though the `rotate` preference (`PREF_ROTATE`) was off by ensuring the in-memory flag is re-read before applying orientation updates. 
- Prevent stale sensor updates from leaving the map misaligned when rotation is disabled or when the fragment lifecycle changes.

### Description

- Add `syncMapRotationPreference()` and call it from `onResume()` and `onLocationChanged()` so the fragment always refreshes the `PREF_ROTATE` value before reacting to location/orientation updates (`app/src/main/java/org/nitri/opentopo/MapFragment.kt`).
- Stop the orientation sensor during `onPause()` and stop/reset it immediately when `syncMapRotationPreference()` finds rotation is disabled, preventing delayed sensor callbacks from rotating the map (`MapFragment.kt`).
- Extend `MapOrientation.reset()` to clear internal tracking state (`mapOrientation` and `previousMapOrientation`) so a north-up reset is applied from a clean baseline (`app/src/main/java/org/nitri/opentopo/util/MapOrientation.kt`).

### Testing

- Ran `./gradlew :app:compileDebugKotlin`, which failed in this environment due to an Android SDK/toolchain issue (`What went wrong: 25.0.1`), so no successful build verification could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9ad9ba9083279cadc80594900386)