### PR TITLE
Add Top-O-Map as an OpenTopoMap source option

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -507,8 +507,8 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
     }
 
     private fun resolveOpenTopoMapTileSource(): ITileSource {
-        return if (openTopoMapSource == OTM_SOURCE_R) {
-            XYTileSource(
+        return when (openTopoMapSource) {
+            OTM_SOURCE_R -> XYTileSource(
                 "OpenTopoMap-R",
                 1,
                 17,
@@ -517,8 +517,18 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 arrayOf("https://tile.openmaps.fr/opentopomap/"),
                 getString(R.string.open_topo_map_r_copyright)
             )
-        } else {
-            TileSourceFactory.OpenTopo
+
+            OTM_SOURCE_TOP_O_MAP -> XYTileSource(
+                "Top-O-Map",
+                1,
+                17,
+                256,
+                ".png",
+                arrayOf("https://tile.top-o-map.de/"),
+                getString(R.string.top_o_map_copyright)
+            )
+
+            else -> TileSourceFactory.OpenTopo
         }
     }
 
@@ -1203,6 +1213,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         private const val BASE_MAP_OSM = 2
         private const val OTM_SOURCE_DEFAULT = "opentopomap"
         private const val OTM_SOURCE_R = "opentopomap_r"
+        private const val OTM_SOURCE_TOP_O_MAP = "top_o_map"
         private const val DEFAULT_ZOOM = 15.0
         private const val DEFAULT_MAX_ZOOM = 17.0
         private val TAG = MapFragment::class.java.simpleName

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -16,9 +16,11 @@
     <string-array name="open_topo_map_source_entries">
         <item>@string/open_topo_map</item>
         <item>@string/open_topo_map_r</item>
+        <item>@string/top_o_map</item>
     </string-array>
     <string-array name="open_topo_map_source_values">
         <item>opentopomap</item>
         <item>opentopomap_r</item>
+        <item>top_o_map</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="layers">Layers</string>
     <string name="open_topo_map">OpenTopoMap</string>
     <string name="open_topo_map_r">OpenTopoMap-R</string>
+    <string name="top_o_map">Top-O-Map</string>
     <string name="open_street_map">OpenStreetMap</string>
     <string name="lonvia_hiking">Lonvia Hiking</string>
     <string name="lonvia_cycling">Lonvia Cycling</string>
@@ -67,6 +68,7 @@
     <string name="about_open_topo_map">Base map by &lt;a href="https://opentopomap.org/"&gt;OpenTopoMap&lt;/a&gt;.</string>
     <string name="about_waymarked_trails">Trail overlays by &lt;a href="https://waymarkedtrails.org/"&gt;Waymarked Trails&lt;/a&gt; by Lonvia.</string>
     <string name="open_topo_map_r_copyright">© OpenTopoMap-R (openmaps.fr)</string>
+    <string name="top_o_map_copyright">© Top-O-Map (top-o-map.de)</string>
 
     <string name="default_marker_name">Marker %1$d</string>
     <string name="edit_marker">Edit Marker</string>


### PR DESCRIPTION
### Motivation
- Provide an additional selectable OpenTopoMap tile provider (`Top-O-Map`) so users can choose tiles from `https://tile.top-o-map.de/{z}/{x}/{y}.png`. 
- Keep the OpenTopoMap source preference consistent with existing selectable providers and include proper attribution text.

### Description
- Added a new preference value `top_o_map` and a visible entry `Top-O-Map` in `app/src/main/res/values/arrays.xml` to expose the new option in the settings UI. 
- Added `top_o_map` display string and `top_o_map_copyright` in `app/src/main/res/values/strings.xml` for user-facing text and copyright attribution. 
- Updated `MapFragment.resolveOpenTopoMapTileSource()` in `app/src/main/java/org/nitri/opentopo/MapFragment.kt` to handle a new `OTM_SOURCE_TOP_O_MAP` constant and return an `XYTileSource` pointing to `https://tile.top-o-map.de/` with the new copyright string. 
- Introduced `OTM_SOURCE_TOP_O_MAP` constant in `MapFragment` companion object and switched the previous `if` to a `when` for clearer multi-source selection.

### Testing
- Ran `./gradlew :app:testDebugUnitTest`, which failed because the `testDebugUnitTest` task name is ambiguous across product flavors. 
- Ran `./gradlew :app:testFossDebugUnitTest`, which failed in this environment due to missing Android SDK configuration (no `sdk.dir`/`ANDROID_HOME` set). 
- No unit tests could be executed successfully in the current environment; changes are limited to resource additions and a simple tile-source selection branch and should be safe to validate with an Android build in a developer environment with SDK configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4984ce6e88327840121c8111dd781)