### PR TITLE
Add marker management UI with selection, GPX import/export, and helpers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,11 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:name=".MarkerListActivity"
+            android:parentActivityName=".MainActivity"
+            android:exported="false"
+            android:label="@string/markers" />
+        <activity
             android:name=".SettingsActivity"
             android:parentActivityName=".MainActivity"
             android:exported="false"

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -900,6 +900,10 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 }
                 return true
             }
+            R.id.action_markers -> {
+                startActivity(Intent(requireActivity(), MarkerListActivity::class.java))
+                return true
+            }
             R.id.action_gpx_zoom -> {
                 disableFollow()
                 listener?.let { zoomToBounds(Utils.area(it.getGpx())) }

--- a/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
@@ -1,0 +1,255 @@
+package org.nitri.opentopo
+
+import android.net.Uri
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.view.ActionMode
+import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.launch
+import org.nitri.opentopo.adapter.MarkerListAdapter
+import org.nitri.opentopo.model.MarkerModel
+import org.nitri.opentopo.util.GpxMarkerExporter
+import org.nitri.opentopo.util.GpxMarkerImporter
+import org.nitri.opentopo.view.MarkerEditorDialog
+import org.nitri.opentopo.viewmodel.MarkerViewModel
+
+class MarkerListActivity : AppCompatActivity() {
+    private val markerViewModel: MarkerViewModel by viewModels()
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var emptyView: TextView
+    private lateinit var adapter: MarkerListAdapter
+
+    private var markers: List<MarkerModel> = emptyList()
+    private val selectedMarkerIds = mutableSetOf<Int>()
+    private var actionMode: ActionMode? = null
+
+    private val exportLauncher =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/gpx+xml")) { uri ->
+            uri?.let { exportSelectedMarkers(it) }
+        }
+
+    private val importLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            uri?.let { importMarkers(it) }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_marker_list)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.markers)
+
+        recyclerView = findViewById(R.id.markerRecyclerView)
+        emptyView = findViewById(R.id.emptyView)
+
+        adapter = MarkerListAdapter(
+            onClick = { marker ->
+                if (actionMode != null) {
+                    toggleSelection(marker.id)
+                } else {
+                    openMarkerEditor(marker)
+                }
+            },
+            onLongClick = { marker ->
+                if (actionMode == null) {
+                    actionMode = startSupportActionMode(selectionActionModeCallback)
+                }
+                toggleSelection(marker.id)
+            }
+        )
+
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        markerViewModel.markers.observe(this) { markerItems ->
+            markers = markerItems.sortedBy { it.seq }
+            adapter.submitList(markers)
+            emptyView.visibility = if (markers.isEmpty()) View.VISIBLE else View.GONE
+
+            selectedMarkerIds.retainAll(markers.map { it.id }.toSet())
+            if (actionMode != null && selectedMarkerIds.isEmpty()) {
+                actionMode?.finish()
+            } else {
+                updateSelectionUi()
+            }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_marker_list, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            R.id.action_import_markers -> {
+                importLauncher.launch(arrayOf("*/*"))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private val selectionActionModeCallback = object : ActionMode.Callback {
+        override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
+            mode.menuInflater.inflate(R.menu.menu_marker_selection, menu)
+            updateSelectionUi()
+            return true
+        }
+
+        override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean = false
+
+        override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
+            when (item.itemId) {
+                R.id.action_select_all_markers -> {
+                    selectedMarkerIds.clear()
+                    selectedMarkerIds.addAll(markers.map { it.id })
+                    updateSelectionUi()
+                    return true
+                }
+                R.id.action_export_selected_markers -> {
+                    if (selectedMarkerIds.isEmpty()) {
+                        Toast.makeText(this@MarkerListActivity, R.string.no_markers_selected, Toast.LENGTH_SHORT).show()
+                    } else {
+                        exportLauncher.launch(DEFAULT_EXPORT_FILENAME)
+                    }
+                    return true
+                }
+                R.id.action_delete_selected_markers -> {
+                    if (selectedMarkerIds.isEmpty()) {
+                        Toast.makeText(this@MarkerListActivity, R.string.no_markers_selected, Toast.LENGTH_SHORT).show()
+                    } else {
+                        showDeleteSelectedConfirmation()
+                    }
+                    return true
+                }
+                else -> return false
+            }
+        }
+
+        override fun onDestroyActionMode(mode: ActionMode) {
+            selectedMarkerIds.clear()
+            actionMode = null
+            updateSelectionUi()
+        }
+    }
+
+    private fun toggleSelection(markerId: Int) {
+        if (selectedMarkerIds.contains(markerId)) {
+            selectedMarkerIds.remove(markerId)
+        } else {
+            selectedMarkerIds.add(markerId)
+        }
+
+        if (selectedMarkerIds.isEmpty()) {
+            actionMode?.finish()
+        } else {
+            updateSelectionUi()
+        }
+    }
+
+    private fun updateSelectionUi() {
+        val selectedCount = selectedMarkerIds.size
+        actionMode?.title = getString(R.string.markers_selected_count, selectedCount)
+        adapter.setSelection(actionMode != null, selectedMarkerIds)
+    }
+
+    private fun openMarkerEditor(marker: MarkerModel) {
+        MarkerEditorDialog.show(
+            context = this,
+            markerModel = marker.copy(),
+            onUpdate = { updated -> markerViewModel.updateMarker(updated) },
+            onDelete = { toDelete -> markerViewModel.removeMarker(toDelete.id) }
+        )
+    }
+
+    private fun showDeleteSelectedConfirmation() {
+        androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(getString(R.string.confirm_delete))
+            .setMessage(getString(R.string.delete_selected_markers_message, selectedMarkerIds.size))
+            .setPositiveButton(R.string.delete) { _, _ ->
+                markerViewModel.removeMarkers(selectedMarkerIds.toList())
+                actionMode?.finish()
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun exportSelectedMarkers(uri: Uri) {
+        val markersToExport = markers.filter { selectedMarkerIds.contains(it.id) }
+        if (markersToExport.isEmpty()) {
+            Toast.makeText(this, R.string.no_markers_selected, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        lifecycleScope.launch {
+            runCatching {
+                contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    GpxMarkerExporter().export(markersToExport, outputStream)
+                } ?: error("Output stream unavailable")
+            }.onSuccess {
+                Toast.makeText(this@MarkerListActivity, R.string.markers_export_success, Toast.LENGTH_SHORT).show()
+            }.onFailure {
+                Toast.makeText(this@MarkerListActivity, R.string.markers_export_failed, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun importMarkers(uri: Uri) {
+        lifecycleScope.launch {
+            runCatching {
+                contentResolver.openInputStream(uri)?.use { inputStream ->
+                    val currentMaxSeq = markers.maxOfOrNull { it.seq } ?: 0
+                    GpxMarkerImporter().import(inputStream, currentMaxSeq)
+                } ?: error("Input stream unavailable")
+            }.onSuccess { result ->
+                if (result.markers.isEmpty()) {
+                    Toast.makeText(
+                        this@MarkerListActivity,
+                        R.string.import_no_valid_waypoints,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    return@onSuccess
+                }
+
+                markerViewModel.addMarkers(result.markers)
+                if (result.skippedCount > 0) {
+                    Toast.makeText(
+                        this@MarkerListActivity,
+                        getString(R.string.import_success_with_skipped, result.markers.size, result.skippedCount),
+                        Toast.LENGTH_LONG
+                    ).show()
+                } else {
+                    Toast.makeText(
+                        this@MarkerListActivity,
+                        getString(R.string.import_success_count, result.markers.size),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }.onFailure {
+                Toast.makeText(this@MarkerListActivity, R.string.markers_import_failed, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_EXPORT_FILENAME = "opentopomap-markers.gpx"
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/adapter/MarkerListAdapter.kt
+++ b/app/src/main/java/org/nitri/opentopo/adapter/MarkerListAdapter.kt
@@ -1,0 +1,68 @@
+package org.nitri.opentopo.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import org.nitri.opentopo.R
+import org.nitri.opentopo.model.MarkerModel
+import java.util.Locale
+
+class MarkerListAdapter(
+    private val onClick: (MarkerModel) -> Unit,
+    private val onLongClick: (MarkerModel) -> Unit
+) : RecyclerView.Adapter<MarkerListAdapter.MarkerViewHolder>() {
+
+    private var markers: List<MarkerModel> = emptyList()
+    private var selectionMode = false
+    private var selectedIds: Set<Int> = emptySet()
+
+    fun submitList(items: List<MarkerModel>) {
+        markers = items
+        notifyDataSetChanged()
+    }
+
+    fun setSelection(selectionMode: Boolean, selectedIds: Set<Int>) {
+        this.selectionMode = selectionMode
+        this.selectedIds = selectedIds
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MarkerViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_marker, parent, false)
+        return MarkerViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = markers.size
+
+    override fun onBindViewHolder(holder: MarkerViewHolder, position: Int) {
+        val marker = markers[position]
+        val name = marker.name.ifBlank {
+            holder.itemView.context.getString(R.string.marker_fallback_coordinates, marker.latitude, marker.longitude)
+        }
+        holder.labelView.text = name
+        holder.coordinatesView.text = String.format(Locale.US, "%.5f, %.5f", marker.latitude, marker.longitude)
+
+        if (selectionMode) {
+            holder.checkBox.visibility = View.VISIBLE
+            holder.checkBox.isChecked = selectedIds.contains(marker.id)
+        } else {
+            holder.checkBox.visibility = View.GONE
+            holder.checkBox.isChecked = false
+        }
+
+        holder.itemView.setOnClickListener { onClick(marker) }
+        holder.itemView.setOnLongClickListener {
+            onLongClick(marker)
+            true
+        }
+    }
+
+    class MarkerViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val labelView: TextView = view.findViewById(R.id.markerLabelText)
+        val coordinatesView: TextView = view.findViewById(R.id.markerCoordinatesText)
+        val checkBox: CheckBox = view.findViewById(R.id.markerSelectedCheckBox)
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/da/MarkerDao.kt
+++ b/app/src/main/java/org/nitri/opentopo/da/MarkerDao.kt
@@ -12,12 +12,21 @@ interface MarkerDao {
     @Query("SELECT * FROM MarkerModel")
     fun getAllMarkers(): LiveData<List<MarkerModel>>
 
+    @Query("SELECT * FROM MarkerModel")
+    suspend fun getAllMarkersNow(): List<MarkerModel>
+
     @Insert
     suspend fun insertMarker(marker: MarkerModel)
+
+    @Insert
+    suspend fun insertMarkers(markers: List<MarkerModel>)
 
     @Update
     suspend fun updateMarker(marker: MarkerModel)
 
     @Query("DELETE FROM MarkerModel WHERE id = :markerId")
     suspend fun deleteMarkerById(markerId: Int)
+
+    @Query("DELETE FROM MarkerModel WHERE id IN (:markerIds)")
+    suspend fun deleteMarkersByIds(markerIds: List<Int>)
 }

--- a/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
+++ b/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
@@ -4,12 +4,8 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
-import android.view.LayoutInflater
-import android.view.Window
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
-import com.google.android.material.textfield.TextInputLayout
 import io.ticofab.androidgpxparser.parser.domain.Gpx
 import org.nitri.opentopo.R
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_ORS_API_KEY
@@ -18,6 +14,7 @@ import org.nitri.opentopo.model.MarkerModel
 import org.nitri.opentopo.nearby.entity.NearbyItem
 import org.osmdroid.tileprovider.MapTileProviderBasic
 import org.nitri.opentopo.util.Utils
+import org.nitri.opentopo.view.MarkerEditorDialog
 import org.osmdroid.tileprovider.tilesource.ITileSource
 import org.osmdroid.tileprovider.tilesource.XYTileSource
 import org.osmdroid.util.GeoPoint
@@ -114,38 +111,17 @@ class OverlayHelper(private val mContext: Context, private val mMapView: MapView
     private val onMarkerInfoEditClickListener : MarkerInfoWindow.OnMarkerInfoEditClickListener =
         object : MarkerInfoWindow.OnMarkerInfoEditClickListener {
             override fun onMarkerInfoEditClick(markerModel: MarkerModel) {
-                val dialogView =
-                    LayoutInflater.from(mContext).inflate(R.layout.dialog_edit_marker, null)
-                val nameInput = dialogView.findViewById<TextInputLayout>(R.id.nameInput)
-                val descriptionInput =
-                    dialogView.findViewById<TextInputLayout>(R.id.descriptionInput)
-
-                nameInput.editText?.setText(markerModel.name)
-                descriptionInput.editText?.setText(markerModel.description)
-
-                val alertDialog = AlertDialog.Builder(mContext)
-                    .setTitle(mContext.getString(R.string.edit_marker))
-                    .setView(dialogView)
-                    .setPositiveButton(mContext.getString(R.string.ok)) { _, _ ->
-                        markerModel.name = nameInput.editText?.text.toString()
-                        markerModel.description = descriptionInput.editText?.text.toString()
-                        markerInteractionListener.onMarkerUpdate(markerModel)
-                    }
-                    .setNegativeButton(mContext.getString(R.string.cancel)) { dialog, _ ->
-                        dialog.dismiss()
-                    }
-                    .setNeutralButton(mContext.getString(R.string.delete)) { _, _ ->
-                        showDeleteConfirmationDialog(mContext) {
-                            if (markerModel.routeWaypoint) {
-                                removeWaypoint(markerModel)
-                            }
-                            markerInteractionListener.onMarkerDelete(markerModel)
+                MarkerEditorDialog.show(
+                    context = mContext,
+                    markerModel = markerModel,
+                    onUpdate = { markerInteractionListener.onMarkerUpdate(it) },
+                    onDelete = {
+                        if (it.routeWaypoint) {
+                            removeWaypoint(it)
                         }
+                        markerInteractionListener.onMarkerDelete(it)
                     }
-                    .create()
-                alertDialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-                alertDialog.show()
-
+                )
             }
         }
 
@@ -159,19 +135,6 @@ class OverlayHelper(private val mContext: Context, private val mMapView: MapView
                 removeWaypoint(markerModel)
             }
         }
-
-    private fun showDeleteConfirmationDialog(context: Context, onDeleteConfirmed: () -> Unit) {
-        val alertDialog = AlertDialog.Builder(context)
-            .setTitle(mContext.getString(R.string.confirm_delete))
-            .setMessage(mContext.getString(R.string.prompt_confirm_delete))
-            .setPositiveButton(mContext.getString(R.string.delete)) { _, _ ->
-                onDeleteConfirmed()
-            }
-            .setNegativeButton(mContext.getString(R.string.cancel), null)
-            .create()
-        alertDialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        alertDialog.show()
-    }
 
     private val nearbyItemGestureListener: OnItemGestureListener<OverlayItem?> =
         object : OnItemGestureListener<OverlayItem?> {

--- a/app/src/main/java/org/nitri/opentopo/util/GpxMarkerExporter.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/GpxMarkerExporter.kt
@@ -1,0 +1,50 @@
+package org.nitri.opentopo.util
+
+import org.nitri.opentopo.model.MarkerModel
+import org.w3c.dom.Document
+import java.io.OutputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+class GpxMarkerExporter {
+    fun export(markers: List<MarkerModel>, outputStream: OutputStream) {
+        val documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        val document: Document = documentBuilder.newDocument()
+
+        val gpxElement = document.createElement("gpx").apply {
+            setAttribute("version", "1.1")
+            setAttribute("creator", "OpenTopoMap Viewer")
+            setAttribute("xmlns", "http://www.topografix.com/GPX/1/1")
+        }
+
+        markers.forEach { marker ->
+            val waypoint = document.createElement("wpt")
+            waypoint.setAttribute("lat", marker.latitude.toString())
+            waypoint.setAttribute("lon", marker.longitude.toString())
+
+            val name = document.createElement("name")
+            name.textContent = marker.name.ifBlank { "${marker.latitude}, ${marker.longitude}" }
+            waypoint.appendChild(name)
+
+            if (marker.description.isNotBlank()) {
+                val desc = document.createElement("desc")
+                desc.textContent = marker.description
+                waypoint.appendChild(desc)
+            }
+
+            gpxElement.appendChild(waypoint)
+        }
+
+        document.appendChild(gpxElement)
+
+        val transformer = TransformerFactory.newInstance().newTransformer().apply {
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty(OutputKeys.ENCODING, "UTF-8")
+        }
+
+        transformer.transform(DOMSource(document), StreamResult(outputStream))
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
@@ -1,0 +1,62 @@
+package org.nitri.opentopo.util
+
+import org.nitri.opentopo.model.MarkerModel
+import org.w3c.dom.Element
+import java.io.InputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
+class GpxMarkerImporter {
+    data class ImportResult(
+        val markers: List<MarkerModel>,
+        val skippedCount: Int
+    )
+
+    fun import(inputStream: InputStream, baseSeq: Int): ImportResult {
+        val documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        val document = documentBuilder.parse(inputStream)
+        val waypointNodes = document.getElementsByTagName("wpt")
+
+        val markers = mutableListOf<MarkerModel>()
+        var skippedCount = 0
+        var seq = baseSeq
+
+        for (index in 0 until waypointNodes.length) {
+            val node = waypointNodes.item(index)
+            if (node !is Element) {
+                skippedCount++
+                continue
+            }
+
+            val latValue = node.getAttribute("lat")
+            val lonValue = node.getAttribute("lon")
+            val latitude = latValue.toDoubleOrNull()
+            val longitude = lonValue.toDoubleOrNull()
+
+            if (latitude == null || longitude == null) {
+                skippedCount++
+                continue
+            }
+
+            seq += 1
+            val name = node.getElementsByTagName("name").item(0)?.textContent
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: "Marker $seq"
+            val description = node.getElementsByTagName("desc").item(0)?.textContent
+                ?.trim()
+                .orEmpty()
+
+            markers.add(
+                MarkerModel(
+                    seq = seq,
+                    latitude = latitude,
+                    longitude = longitude,
+                    name = name,
+                    description = description
+                )
+            )
+        }
+
+        return ImportResult(markers, skippedCount)
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
@@ -1,0 +1,59 @@
+package org.nitri.opentopo.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.Window
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.textfield.TextInputLayout
+import org.nitri.opentopo.R
+import org.nitri.opentopo.model.MarkerModel
+
+object MarkerEditorDialog {
+    fun show(
+        context: Context,
+        markerModel: MarkerModel,
+        onUpdate: (MarkerModel) -> Unit,
+        onDelete: ((MarkerModel) -> Unit)? = null
+    ) {
+        val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_edit_marker, null)
+        val nameInput = dialogView.findViewById<TextInputLayout>(R.id.nameInput)
+        val descriptionInput = dialogView.findViewById<TextInputLayout>(R.id.descriptionInput)
+
+        nameInput.editText?.setText(markerModel.name)
+        descriptionInput.editText?.setText(markerModel.description)
+
+        val dialogBuilder = AlertDialog.Builder(context)
+            .setTitle(context.getString(R.string.edit_marker))
+            .setView(dialogView)
+            .setPositiveButton(context.getString(R.string.ok)) { _, _ ->
+                markerModel.name = nameInput.editText?.text.toString()
+                markerModel.description = descriptionInput.editText?.text.toString()
+                onUpdate(markerModel)
+            }
+            .setNegativeButton(context.getString(R.string.cancel)) { dialog, _ ->
+                dialog.dismiss()
+            }
+
+        if (onDelete != null) {
+            dialogBuilder.setNeutralButton(context.getString(R.string.delete)) { _, _ ->
+                AlertDialog.Builder(context)
+                    .setTitle(context.getString(R.string.confirm_delete))
+                    .setMessage(context.getString(R.string.prompt_confirm_delete))
+                    .setPositiveButton(context.getString(R.string.delete)) { _, _ ->
+                        onDelete(markerModel)
+                    }
+                    .setNegativeButton(context.getString(R.string.cancel), null)
+                    .create()
+                    .also {
+                        it.requestWindowFeature(Window.FEATURE_NO_TITLE)
+                        it.show()
+                    }
+            }
+        }
+
+        dialogBuilder.create().also {
+            it.requestWindowFeature(Window.FEATURE_NO_TITLE)
+            it.show()
+        }
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/viewmodel/MarkerViewModel.kt
+++ b/app/src/main/java/org/nitri/opentopo/viewmodel/MarkerViewModel.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.nitri.opentopo.model.MarkerModel
 import org.nitri.opentopo.overlay.OverlayDatabase
 
@@ -17,8 +19,22 @@ class MarkerViewModel(application: Application) : AndroidViewModel(application) 
         db.markerDao().insertMarker(marker)
     }
 
+    fun addMarkers(markers: List<MarkerModel>) = viewModelScope.launch {
+        db.markerDao().insertMarkers(markers)
+    }
+
+    suspend fun getAllMarkersNow(): List<MarkerModel> {
+        return withContext(Dispatchers.IO) {
+            db.markerDao().getAllMarkersNow()
+        }
+    }
+
     fun removeMarker(markerId: Int) = viewModelScope.launch {
         db.markerDao().deleteMarkerById(markerId)
+    }
+
+    fun removeMarkers(markerIds: List<Int>) = viewModelScope.launch {
+        db.markerDao().deleteMarkersByIds(markerIds)
     }
 
     fun updateMarker(marker: MarkerModel) = viewModelScope.launch {

--- a/app/src/main/res/layout/activity_marker_list.xml
+++ b/app/src/main/res/layout/activity_marker_list.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary" />
+
+    <TextView
+        android:id="@+id/emptyView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="24dp"
+        android:text="@string/no_markers_available"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/markerRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_marker.xml
+++ b/app/src/main/res/layout/item_marker.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="12dp">
+
+    <CheckBox
+        android:id="@+id/markerSelectedCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="false"
+        android:focusable="false"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/markerLabelText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/markerCoordinatesText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -54,6 +54,12 @@
         android:visible="true"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/action_markers"
+        android:icon="@drawable/ic_place"
+        android:title="@string/markers"
+        android:visible="true"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/action_settings"
         android:icon="@drawable/ic_action_settings"
         android:title="@string/settings"

--- a/app/src/main/res/menu/menu_marker_list.xml
+++ b/app/src/main/res/menu/menu_marker_list.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_import_markers"
+        android:icon="@drawable/ic_action_gpx"
+        android:title="@string/import_gpx"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/menu/menu_marker_selection.xml
+++ b/app/src/main/res/menu/menu_marker_selection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_select_all_markers"
+        android:title="@string/select_all"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_export_selected_markers"
+        android:title="@string/export_selected"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_delete_selected_markers"
+        android:title="@string/delete_selected"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,24 @@
 
     <string name="no_browser_found" translatable="false">No browser app found to open link</string>
 
+
+    <string name="markers">Markers</string>
+    <string name="import_gpx">Import GPX</string>
+    <string name="select_all">Select all</string>
+    <string name="export_selected">Export selected</string>
+    <string name="delete_selected">Delete selected</string>
+    <string name="no_markers_available">No markers available.</string>
+    <string name="no_markers_selected">No markers selected.</string>
+    <string name="markers_selected_count">%1$d selected</string>
+    <string name="delete_selected_markers_message">Delete %1$d selected markers?
+
+This cannot be undone.</string>
+    <string name="markers_export_success">Markers exported.</string>
+    <string name="markers_export_failed">Export failed: could not write the GPX file.</string>
+    <string name="markers_import_failed">Import failed.</string>
+    <string name="import_no_valid_waypoints">No valid GPX waypoints found.</string>
+    <string name="import_success_count">Imported %1$d markers.</string>
+    <string name="import_success_with_skipped">Imported %1$d markers. Skipped %2$d invalid waypoints.</string>
+    <string name="marker_fallback_coordinates">%1$.5f, %2$.5f</string>
+
 </resources>

--- a/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
+++ b/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
@@ -1,0 +1,48 @@
+package org.nitri.opentopo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.nitri.opentopo.model.MarkerModel
+import org.nitri.opentopo.util.GpxMarkerExporter
+import org.nitri.opentopo.util.GpxMarkerImporter
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class GpxMarkerImportExportTest {
+    @Test
+    fun exportMarkers_writesWaypoints() {
+        val markers = listOf(
+            MarkerModel(seq = 1, latitude = 51.0, longitude = 6.6, name = "A & B", description = "note"),
+            MarkerModel(seq = 2, latitude = 52.0, longitude = 7.7, name = "", description = "")
+        )
+
+        val output = ByteArrayOutputStream()
+        GpxMarkerExporter().export(markers, output)
+        val xml = output.toString(Charsets.UTF_8)
+
+        assertTrue(xml.contains("<wpt lat=\"51.0\" lon=\"6.6\""))
+        assertTrue(xml.contains("<name>A &amp; B</name>"))
+        assertTrue(xml.contains("<desc>note</desc>"))
+        assertTrue(xml.contains("<wpt lat=\"52.0\" lon=\"7.7\""))
+    }
+
+    @Test
+    fun importMarkers_readsValidWaypointsAndSkipsInvalid() {
+        val gpx = """
+            <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+              <wpt lat="51.123" lon="6.456"><name>Point 1</name><desc>Desc 1</desc></wpt>
+              <wpt lat="invalid" lon="6.456"><name>Bad Point</name></wpt>
+              <wpt lat="50.0" lon="8.0"></wpt>
+            </gpx>
+        """.trimIndent()
+
+        val result = GpxMarkerImporter().import(ByteArrayInputStream(gpx.toByteArray()), 10)
+
+        assertEquals(2, result.markers.size)
+        assertEquals(1, result.skippedCount)
+        assertEquals("Point 1", result.markers[0].name)
+        assertEquals("Desc 1", result.markers[0].description)
+        assertEquals("Marker 12", result.markers[1].name)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, complete marker management feature (list, edit, select, delete, import/export) following the existing XML/View UI approach and using the Storage Access Framework for file access. 
- Reuse the existing marker edit behavior on the map to avoid duplicating UX and to keep marker/map synchronization simple. 
- Keep GPX-specific logic out of UI code by adding dedicated importer/exporter helpers and minimal DB extensions for bulk operations.

### Description
- Added a new `MarkerListActivity` plus layouts, menus and `MarkerListAdapter` to display saved markers, support long-press selection mode, `Select all`, `Delete selected` (with confirmation), and `Export selected` actions (SAF `CreateDocument`).
- Implemented GPX helpers `GpxMarkerExporter` and `GpxMarkerImporter` that write/read GPX 1.1 `<wpt>` entries with `<name>` and `<desc>`, escaping/ignoring invalid entries and returning import results (imported markers + skipped count).
- Reused marker edit UX by introducing `MarkerEditorDialog` and wiring it into the overlay code so list taps and map marker edits share the same dialog and behavior.
- Extended `MarkerDao` and `MarkerViewModel` with bulk operations and a synchronous fetch helper (`getAllMarkersNow` / `insertMarkers` / `deleteMarkersByIds`) to support import and multi-delete flows.
- Integrated the new screen into the app: added `Markers` menu item, registered `MarkerListActivity` in the manifest, and added user-facing strings and resource files for layouts/menus.
- Added unit tests `GpxMarkerImportExportTest` covering GPX export XML escaping and import skipping behavior for invalid waypoints.

### Testing
- Added unit tests: `GpxMarkerImportExportTest` which validates GPX export produces escaped XML and that importer reads valid `<wpt>` elements while skipping invalid ones (tests are present under `app/src/test`).
- Attempted to run the unit tests with `./gradlew testFossDebugUnitTest`, but the test run failed in this environment due to missing Android SDK configuration (`SDK location not found`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3a21368483279d3550fcd44912ca)