### PR TITLE
Add dedicated Remove GPX menu action

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -884,6 +884,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         val gpxVisible = gpxDisplayState != GpxDisplayState.IDLE
         menu.findItem(R.id.action_gpx_details).isVisible = gpxVisible
         menu.findItem(R.id.action_gpx_zoom).isVisible = gpxVisible
+        menu.findItem(R.id.action_gpx_remove).isVisible = gpxVisible
 
         listener?.let {
             menu.findItem(R.id.action_privacy_settings).isVisible = it.isPrivacyOptionsRequired()
@@ -954,6 +955,10 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             R.id.action_gpx_zoom -> {
                 disableFollow()
                 listener?.let { zoomToBounds(Utils.area(it.getGpx())) }
+                return true
+            }
+            R.id.action_gpx_remove -> {
+                showGpxDialog()
                 return true
             }
             R.id.action_layers -> {

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -958,7 +958,12 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 return true
             }
             R.id.action_gpx_remove -> {
-                showGpxDialog()
+                showGpxDialog {
+                    markerViewModel.markers.value?.forEach {
+                        it.routeWaypoint = false
+                    }
+                    listener?.clearGpx()
+                }
                 return true
             }
             R.id.action_layers -> {

--- a/app/src/main/res/drawable-anydpi/ic_action_delete.xml
+++ b/app/src/main/res/drawable-anydpi/ic_action_delete.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+    
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -36,6 +36,11 @@
         android:visible="false"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/action_gpx_remove"
+        android:title="@string/gpx_remove"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_layers"
         android:icon="@drawable/ic_action_layers"
         android:title="@string/layers"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -37,6 +37,7 @@
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_gpx_remove"
+        android:icon="@drawable/ic_action_delete"
         android:title="@string/gpx_remove"
         android:visible="false"
         app:showAsAction="never" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,7 @@
     <string name="discard_current_gpx">Die aktuelle GPX wird verworfen.</string>
     <string name="gpx_details">GPX Details</string>
     <string name="gpx_zoom">Zoom zu GPX</string>
+    <string name="gpx_remove">GPX entfernen</string>
 
     <string name="location_details">Standortdetails</string>
     <string name="label_latitude">Breitengrad:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,6 +10,7 @@
     <string name="discard_current_gpx">El GPX actual será descartado.</string>
     <string name="gpx_details">Detalles del GPX</string>
     <string name="gpx_zoom">Zoom al GPX</string>
+    <string name="gpx_remove">Eliminar GPX</string>
 
     <string name="location_details">Detalle de la ubicación</string>
     <string name="label_latitude">Latitud:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,6 +10,7 @@
     <string name="discard_current_gpx">Le GPX actuel sera supprimé.</string>
     <string name="gpx_details">Détails du GPX</string>
     <string name="gpx_zoom">Zoom sur le GPX</string>
+    <string name="gpx_remove">Supprimer le GPX</string>
 
     <string name="location_details">Détail de la position</string>
     <string name="label_latitude">Latitude :</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -10,6 +10,7 @@
     <string name="discard_current_gpx">Il GPX caricato verrà sostituito</string>
     <string name="gpx_details">Dettagli GPX</string>
     <string name="gpx_zoom">Centra GPX</string>
+    <string name="gpx_remove">Rimuovi GPX</string>
 
     <string name="location_details">Dettagli posizione</string>
     <string name="label_latitude">Latitudine:</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -10,6 +10,7 @@
     <string name="discard_current_gpx">De huidige GPX wordt verwijderd.</string>
     <string name="gpx_details">GPX details</string>
     <string name="gpx_zoom">Zoom naar GPX</string>
+    <string name="gpx_remove">GPX verwijderen</string>
 
     <string name="location_details">Locatie-detail</string>
     <string name="label_latitude">Breedtegraad:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="discard_current_gpx">The current GPX will be discarded.</string>
     <string name="gpx_details">GPX details</string>
     <string name="gpx_zoom">Zoom to GPX</string>
+    <string name="gpx_remove">Remove GPX</string>
 
     <string name="location_details">Location detail</string>
     <string name="label_latitude">Latitude:</string>


### PR DESCRIPTION
### Motivation
- Provide an explicit way to discard the currently displayed GPX without launching the file picker or starting the import flow.

### Description
- Add a new overflow menu item `action_gpx_remove` in `app/src/main/res/menu/menu_main.xml` and a `gpx_remove` label in `app/src/main/res/values/strings.xml` to surface the action in the UI.
- Update `MapFragment` to show the new remove action only when a GPX is displayed by setting its visibility in `onPrepareOptionsMenu`, and handle `R.id.action_gpx_remove` to invoke the existing discard confirmation (`showGpxDialog()`), which clears the GPX without calling `selectGpx()`.
- Preserve the existing `action_gpx` behavior so users can still replace a GPX by choosing a new file.

### Testing
- Ran `./gradlew :app:testDebugUnitTest`, which failed because the task name is ambiguous in this project (multiple test variants exist). 
- Ran `./gradlew :app:testFossDebugUnitTest`, which failed in this environment because the Android SDK location is not configured, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d7a0375c8327aa8c0a9478795e7a)