### PR TITLE
Add KML import and map overlay support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'com.google.android.material:material:1.14.0'
     implementation 'org.osmdroid:osmdroid-android:6.1.20'
+    implementation 'org.osmdroid:osmbonuspack:6.9.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.squareup.retrofit2:retrofit:3.0.0'

--- a/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
@@ -42,6 +42,7 @@ import org.nitri.opentopo.SettingsActivity.Companion.PREF_FULLSCREEN_ON_MAP_TAP
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_KEEP_SCREEN_ON
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_ORS_API_KEY
 import org.nitri.opentopo.viewmodel.GpxViewModel
+import org.nitri.opentopo.viewmodel.KmlViewModel
 import org.nitri.opentopo.nearby.NearbyFragment
 import org.nitri.opentopo.nearby.entity.NearbyItem
 import org.nitri.opentopo.util.Utils
@@ -59,11 +60,11 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     private var gpxUriString: String? = null
     private var gpxUri: Uri? = null
     private var shouldZoomToGpx = false
-    private var kmlUriString: String? = null
     private var shouldZoomToKml = false
     override var selectedNearbyPlace: NearbyItem? = null
     private var mapFragment: MapFragment? = null
     private val gpxViewModel: GpxViewModel by viewModels()
+    private val kmlViewModel: KmlViewModel by viewModels()
     override var isFullscreen = false
 
     private var windowInsetsController: WindowInsetsControllerCompat? = null
@@ -118,7 +119,7 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
 
         if (savedInstanceState != null) {
             gpxUriString = savedInstanceState.getString(GPX_URI_STATE)
-            kmlUriString = savedInstanceState.getString(KML_URI_STATE)
+            kmlViewModel.kmlUriString = savedInstanceState.getString(KML_URI_STATE)
         }
 
         mapContainer = findViewById(R.id.map_container)
@@ -360,7 +361,7 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     }
 
     override fun setKml() {
-        kmlUriString?.takeIf { it.isNotEmpty() }?.let { uriString ->
+        kmlViewModel.kmlUriString?.takeIf { it.isNotEmpty() }?.let { uriString ->
             parseKml(uriString.toUri())
         }
     }
@@ -376,8 +377,8 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         if (!TextUtils.isEmpty(gpxUriString)) {
             outState.putString(GPX_URI_STATE, gpxUriString)
         }
-        if (!TextUtils.isEmpty(kmlUriString)) {
-            outState.putString(KML_URI_STATE, kmlUriString)
+        if (!TextUtils.isEmpty(kmlViewModel.kmlUriString)) {
+            outState.putString(KML_URI_STATE, kmlViewModel.kmlUriString)
         }
         mapFragment?.let {
             supportFragmentManager.putFragment(outState, MAP_FRAGMENT_TAG, it)
@@ -443,7 +444,7 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     private fun handleParsedKml(kmlDocument: KmlDocument, kmlUriString: String?) {
         (supportFragmentManager.findFragmentByTag(MAP_FRAGMENT_TAG) as? MapFragment)?.let { mapFragment ->
             mapFragment.setKml(kmlDocument, shouldZoomToKml)
-            kmlUriString?.let { this.kmlUriString = it }
+            kmlUriString?.let { kmlViewModel.kmlUriString = it }
             shouldZoomToKml = false
         }
     }
@@ -507,7 +508,7 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     }
 
     override fun clearKml() {
-        kmlUriString = null
+        kmlViewModel.kmlUriString = null
     }
 
     override fun showNearbyPlace(nearbyItem: NearbyItem?) {

--- a/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
@@ -49,6 +49,7 @@ import org.osmdroid.util.GeoPoint
 import androidx.core.net.toUri
 import org.nitri.ors.Ors
 import org.nitri.ors.OrsClient
+import org.osmdroid.bonuspack.kml.KmlDocument
 
 open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInteractionListener,
     GpxDetailFragment.OnFragmentInteractionListener, NearbyFragment.OnFragmentInteractionListener {
@@ -58,6 +59,8 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     private var gpxUriString: String? = null
     private var gpxUri: Uri? = null
     private var shouldZoomToGpx = false
+    private var kmlUriString: String? = null
+    private var shouldZoomToKml = false
     override var selectedNearbyPlace: NearbyItem? = null
     private var mapFragment: MapFragment? = null
     private val gpxViewModel: GpxViewModel by viewModels()
@@ -115,6 +118,7 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
 
         if (savedInstanceState != null) {
             gpxUriString = savedInstanceState.getString(GPX_URI_STATE)
+            kmlUriString = savedInstanceState.getString(KML_URI_STATE)
         }
 
         mapContainer = findViewById(R.id.map_container)
@@ -355,6 +359,12 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         }
     }
 
+    override fun setKml() {
+        kmlUriString?.takeIf { it.isNotEmpty() }?.let { uriString ->
+            parseKml(uriString.toUri())
+        }
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
             onBackPressedDispatcher.onBackPressed()
@@ -365,6 +375,9 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
     override fun onSaveInstanceState(outState: Bundle) {
         if (!TextUtils.isEmpty(gpxUriString)) {
             outState.putString(GPX_URI_STATE, gpxUriString)
+        }
+        if (!TextUtils.isEmpty(kmlUriString)) {
+            outState.putString(KML_URI_STATE, kmlUriString)
         }
         mapFragment?.let {
             supportFragmentManager.putFragment(outState, MAP_FRAGMENT_TAG, it)
@@ -392,6 +405,51 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
             e.printStackTrace()
             showGpxError(getString(R.string.invalid_gpx) + ": ${e.message}")
         }
+    }
+
+    override fun selectKml() {
+        val intent = Intent(Intent.ACTION_GET_CONTENT)
+        intent.addCategory(Intent.CATEGORY_OPENABLE)
+        intent.type = "*/*"
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/vnd.google-earth.kml+xml", "application/vnd.google-earth.kmz"))
+        val activityIntent = Intent.createChooser(intent, "KML")
+        kmlActivityResultLauncher.launch(activityIntent)
+    }
+
+    private var kmlActivityResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            result.data?.data?.let {
+                shouldZoomToKml = true
+                parseKml(it)
+            }
+        }
+    }
+
+    private fun parseKml(uri: Uri) {
+        try {
+            contentResolver.openInputStream(uri)?.use { inputStream ->
+                val kmlDocument = KmlDocument()
+                kmlDocument.parseKMLStream(inputStream, null)
+                handleParsedKml(kmlDocument, uri.toString())
+            } ?: showKmlError(getString(R.string.invalid_kml) + ": empty input stream")
+        } catch (e: Exception) {
+            e.printStackTrace()
+            showKmlError(getString(R.string.invalid_kml) + ": ${e.message}")
+        }
+    }
+
+    private fun handleParsedKml(kmlDocument: KmlDocument, kmlUriString: String?) {
+        (supportFragmentManager.findFragmentByTag(MAP_FRAGMENT_TAG) as? MapFragment)?.let { mapFragment ->
+            mapFragment.setKml(kmlDocument, shouldZoomToKml)
+            kmlUriString?.let { this.kmlUriString = it }
+            shouldZoomToKml = false
+        }
+    }
+
+    private fun showKmlError(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
     override fun parseCalculatedGpx(gpxString: String) {
@@ -448,6 +506,10 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         gpxUriString = null
     }
 
+    override fun clearKml() {
+        kmlUriString = null
+    }
+
     override fun showNearbyPlace(nearbyItem: NearbyItem?) {
         selectedNearbyPlace = nearbyItem
         supportFragmentManager.popBackStack()
@@ -496,5 +558,6 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         private const val NEARBY_FRAGMENT_TAG = "nearby_fragment"
         private const val REQUEST_LOCATION_PERMISSION = 1
         private const val GPX_URI_STATE = "gpx_uri"
+        private const val KML_URI_STATE = "kml_uri"
     }
 }

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -73,6 +73,7 @@ import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.MapEventsOverlay
 import org.osmdroid.views.overlay.ScaleBarOverlay
+import org.osmdroid.bonuspack.kml.KmlDocument
 import org.osmdroid.views.overlay.compass.CompassOverlay
 import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay
@@ -92,6 +93,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         LOADED_FROM_FILE, // GPX loaded from file
         CALCULATED      // GPX calculated from routing service
     }
+    private var kmlDocument: KmlDocument? = null
 
     private var gpxDisplayState: GpxDisplayState = GpxDisplayState.IDLE
     private var orientationSensor: OrientationSensor? = null
@@ -323,6 +325,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
 
     private fun initializeMapState(savedInstanceState: Bundle?) {
         listener?.setGpx()
+        listener?.setKml()
 
         // Check if there's already a GPX track loaded and update the state accordingly
         if (overlayHelper?.hasGpx() == true) {
@@ -777,6 +780,24 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         }
     }
 
+    fun setKml(document: KmlDocument, zoom: Boolean) {
+        kmlDocument = document
+        overlayHelper?.setKml(document)
+        if (activity != null) (activity as AppCompatActivity).supportInvalidateOptionsMenu()
+        if (zoom) {
+            document.mKmlRoot.boundingBox?.let {
+                disableFollow()
+                zoomToBounds(it)
+            }
+        }
+    }
+
+    private fun clearKml() {
+        kmlDocument = null
+        overlayHelper?.clearKml()
+        if (activity != null) (activity as AppCompatActivity).supportInvalidateOptionsMenu()
+    }
+
     private fun removeGpx() {
         overlayHelper?.let {
             it.clearGpx()
@@ -885,6 +906,9 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         menu.findItem(R.id.action_gpx_details).isVisible = gpxVisible
         menu.findItem(R.id.action_gpx_zoom).isVisible = gpxVisible
         menu.findItem(R.id.action_gpx_remove).isVisible = gpxVisible
+        val kmlVisible = overlayHelper?.hasKml() == true && kmlDocument != null
+        menu.findItem(R.id.action_kml_zoom).isVisible = kmlVisible
+        menu.findItem(R.id.action_kml_remove).isVisible = kmlVisible
 
         listener?.let {
             menu.findItem(R.id.action_privacy_settings).isVisible = it.isPrivacyOptionsRequired()
@@ -912,6 +936,10 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 locationViewModel?.currentLocation?.value?.let { location ->
                     mapView.controller.animateTo(GeoPoint(location))
                 }
+                return true
+            }
+            R.id.action_kml -> {
+                listener?.selectKml()
                 return true
             }
             R.id.action_follow -> {
@@ -964,6 +992,18 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                     }
                     listener?.clearGpx()
                 }
+                return true
+            }
+            R.id.action_kml_zoom -> {
+                kmlDocument?.mKmlRoot?.boundingBox?.let {
+                    disableFollow()
+                    zoomToBounds(it)
+                }
+                return true
+            }
+            R.id.action_kml_remove -> {
+                clearKml()
+                listener?.clearKml()
                 return true
             }
             R.id.action_layers -> {
@@ -1186,11 +1226,13 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
          * Start GPX file selection flow
          */
         fun selectGpx()
+        fun selectKml()
 
         /**
          * Request to set a GPX layer, e.g. after a configuration change
          */
         fun setGpx()
+        fun setKml()
 
         /**
          * Retrieve the current GPX
@@ -1203,6 +1245,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
          * Clear GPX so it won't be restored on config change
          */
         fun clearGpx()
+        fun clearKml()
 
         /**
          * Present GPX details

--- a/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
+++ b/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
@@ -25,6 +25,8 @@ import org.osmdroid.views.overlay.Marker.OnMarkerDragListener
 import org.osmdroid.views.overlay.OverlayItem
 import org.osmdroid.views.overlay.OverlayItem.HotspotPlace
 import org.osmdroid.views.overlay.TilesOverlay
+import org.osmdroid.views.overlay.FolderOverlay
+import org.osmdroid.bonuspack.kml.KmlDocument
 
 class OverlayHelper(private val mContext: Context, private val mMapView: MapView?) {
     private var wayPointOverlay: ItemizedIconInfoOverlay? = null
@@ -159,6 +161,7 @@ class OverlayHelper(private val mContext: Context, private val mMapView: MapView
     private var markerInfoWindow: MarkerInfoWindow? = null
 
     private var trackOverlay: TrackOverlay? = null
+    private var kmlOverlay: FolderOverlay? = null
     private val mapMarkers = ArrayList<Marker>()
 
     /**
@@ -231,6 +234,26 @@ class OverlayHelper(private val mContext: Context, private val mMapView: MapView
             }
         }
     }
+
+    fun setKml(kmlDocument: KmlDocument) {
+        clearKml()
+        val folderOverlay = kmlDocument.mKmlRoot.buildOverlay(mMapView, null, null, kmlDocument) as? FolderOverlay
+        folderOverlay?.let {
+            kmlOverlay = it
+            mMapView?.overlays?.add(it)
+            mMapView?.invalidate()
+        }
+    }
+
+    fun clearKml() {
+        kmlOverlay?.let { overlay ->
+            mMapView?.overlays?.remove(overlay)
+        }
+        kmlOverlay = null
+        mMapView?.invalidate()
+    }
+
+    fun hasKml(): Boolean = kmlOverlay != null
 
     /**
      * Set the collection of user markers

--- a/app/src/main/java/org/nitri/opentopo/viewmodel/KmlViewModel.kt
+++ b/app/src/main/java/org/nitri/opentopo/viewmodel/KmlViewModel.kt
@@ -1,0 +1,7 @@
+package org.nitri.opentopo.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class KmlViewModel : ViewModel() {
+    var kmlUriString: String? = null
+}

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -36,6 +36,20 @@
         android:visible="false"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/action_kml"
+        android:title="@string/kml"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_kml_zoom"
+        android:title="@string/kml_zoom"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_kml_remove"
+        android:title="@string/kml_remove"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_gpx_remove"
         android:icon="@drawable/ic_action_delete"
         android:title="@string/gpx_remove"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,10 @@
     <string name="gpx_details">GPX details</string>
     <string name="gpx_zoom">Zoom to GPX</string>
     <string name="gpx_remove">Remove GPX</string>
+    <string name="kml">KML</string>
+    <string name="kml_zoom">Zoom to KML</string>
+    <string name="kml_remove">Remove KML</string>
+    <string name="invalid_kml">Invalid KML</string>
 
     <string name="location_details">Location detail</string>
     <string name="label_latitude">Latitude:</string>


### PR DESCRIPTION
### Motivation
- Provide KML/KMZ import and on‑map rendering so users can open KML files (placemarks, lines, polygons) similar to existing GPX support. 
- Reuse `osmbonuspack` KML parsing/overlay functionality to avoid reimplementing KML rendering and to keep behavior consistent with osmdroid overlays.

### Description
- Added `org.osmdroid:osmbonuspack:6.9.0` to `app/build.gradle` to enable `KmlDocument` parsing and `FolderOverlay` creation.
- Implemented KML file selection and parsing in `BaseMainActivity`: `selectKml()` picker, `kmlActivityResultLauncher`, `parseKml()` using `KmlDocument.parseKMLStream(...)`, `handleParsedKml()`, saved/restore of `kml_uri` state and `showKmlError()` for error messages.
- Extended `MapFragment` to hold KML state (`kmlDocument`), call `listener.setKml()` during initialization, and expose `setKml()`/`clearKml()` methods plus menu handlers for `action_kml`, `action_kml_zoom` and `action_kml_remove` to zoom to KML bounding box and remove the overlay.
- Extended `OverlayHelper` with `setKml(kmlDocument: KmlDocument)`, `clearKml()` and `hasKml()` using `kmlDocument.mKmlRoot.buildOverlay(...)` to create and manage a `FolderOverlay` on the map.
- Added menu entries and string resources for the KML actions (`KML`, `Zoom to KML`, `Remove KML`, `Invalid KML`) in `menu_main.xml` and `strings.xml`.

### Testing
- Attempted to compile the app with `./gradlew :app:compileFossDebugKotlin`, but the build failed in this environment because the Android SDK location is not configured (error: `SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file`).
- No automated unit/instrumentation tests were executed in this environment due to the missing SDK; manual runtime verification with the included sample KML is recommended once an Android build environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07233d28f08327b2243815d14ec341)