### PR TITLE
ci: upgrade workflow actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/android-foss-release.yml
+++ b/.github/workflows/android-foss-release.yml
@@ -20,17 +20,17 @@ jobs:
       KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Restore signing key from secret
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > keystore.jks

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
### Motivation

- Address GitHub Actions deprecation warning for Node.js 20 by switching to action majors that support Node.js 24.

### Description

- Bumped action majors in CI workflow files: `actions/checkout@v4` → `actions/checkout@v6`, `actions/setup-java@v4` → `actions/setup-java@v5`, and `gradle/actions/setup-gradle@v4` → `gradle/actions/setup-gradle@v5`.
- Applied these updates in both `.github/workflows/android.yml` and `.github/workflows/android-foss-release.yml` with no other logic changes.

### Testing

- Ran `rg` to search workflows for the old action references and confirmed updates completed successfully.
- Generated and reviewed the diff via `git diff` to verify only the action version lines changed.
- Committed the changes with `git commit`, and inspected workflow files with `sed`/`nl` to confirm the new versions; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0994c95d7c8327ada09ec797460250)