### PR TITLE
Harden GPX XML parsing against XXE and add unit test

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
@@ -3,6 +3,7 @@ package org.nitri.opentopo.util
 import org.nitri.opentopo.model.MarkerModel
 import org.w3c.dom.Element
 import java.io.InputStream
+import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 
 class GpxMarkerImporter {
@@ -12,7 +13,8 @@ class GpxMarkerImporter {
     )
 
     fun import(inputStream: InputStream, baseSeq: Int): ImportResult {
-        val documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        val documentBuilderFactory = createSecureDocumentBuilderFactory()
+        val documentBuilder = documentBuilderFactory.newDocumentBuilder()
         val document = documentBuilder.parse(inputStream)
         val waypointNodes = document.getElementsByTagName("wpt")
 
@@ -59,4 +61,18 @@ class GpxMarkerImporter {
 
         return ImportResult(markers, skippedCount)
     }
+
+    private fun createSecureDocumentBuilderFactory(): DocumentBuilderFactory =
+        DocumentBuilderFactory.newInstance().apply {
+            setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+            isXIncludeAware = false
+            isExpandEntityReferences = false
+        }
 }
+

--- a/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
@@ -7,6 +7,11 @@ import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 
 class GpxMarkerImporter {
+    companion object {
+        private const val XML_ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD"
+        private const val XML_ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema"
+    }
+
     data class ImportResult(
         val markers: List<MarkerModel>,
         val skippedCount: Int
@@ -69,8 +74,8 @@ class GpxMarkerImporter {
             setFeature("http://xml.org/sax/features/external-general-entities", false)
             setFeature("http://xml.org/sax/features/external-parameter-entities", false)
             setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+            setAttribute(XML_ACCESS_EXTERNAL_DTD, "")
+            setAttribute(XML_ACCESS_EXTERNAL_SCHEMA, "")
             isXIncludeAware = false
             isExpandEntityReferences = false
         }

--- a/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
+++ b/app/src/main/java/org/nitri/opentopo/util/GpxMarkerImporter.kt
@@ -2,6 +2,8 @@ package org.nitri.opentopo.util
 
 import org.nitri.opentopo.model.MarkerModel
 import org.w3c.dom.Element
+import org.xml.sax.ErrorHandler
+import org.xml.sax.SAXParseException
 import java.io.InputStream
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
@@ -17,9 +19,23 @@ class GpxMarkerImporter {
         val skippedCount: Int
     )
 
+    private object RethrowingErrorHandler : ErrorHandler {
+        override fun warning(exception: SAXParseException) = Unit
+
+        override fun error(exception: SAXParseException) {
+            throw exception
+        }
+
+        override fun fatalError(exception: SAXParseException) {
+            throw exception
+        }
+    }
+
     fun import(inputStream: InputStream, baseSeq: Int): ImportResult {
         val documentBuilderFactory = createSecureDocumentBuilderFactory()
-        val documentBuilder = documentBuilderFactory.newDocumentBuilder()
+        val documentBuilder = documentBuilderFactory.newDocumentBuilder().apply {
+            setErrorHandler(RethrowingErrorHandler)
+        }
         val document = documentBuilder.parse(inputStream)
         val waypointNodes = document.getElementsByTagName("wpt")
 

--- a/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
+++ b/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
@@ -1,6 +1,7 @@
 package org.nitri.opentopo
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.nitri.opentopo.model.MarkerModel
@@ -8,6 +9,7 @@ import org.nitri.opentopo.util.GpxMarkerExporter
 import org.nitri.opentopo.util.GpxMarkerImporter
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 
 class GpxMarkerImportExportTest {
     @Test
@@ -46,8 +48,8 @@ class GpxMarkerImportExportTest {
         assertEquals("Marker 12", result.markers[1].name)
     }
 
-    @Test(expected = org.xml.sax.SAXParseException::class)
-    fun importMarkers_rejectsDoctypeToPreventXxe() {
+    @Test
+    fun importMarkers_rejectsDoctypeToPreventXxeWithoutLoggingParserError() {
         val gpx = """
             <?xml version="1.0"?>
             <!DOCTYPE gpx [
@@ -58,6 +60,18 @@ class GpxMarkerImportExportTest {
             </gpx>
         """.trimIndent()
 
-        GpxMarkerImporter().import(ByteArrayInputStream(gpx.toByteArray()), 0)
+        val originalErr = System.err
+        val parserErr = ByteArrayOutputStream()
+        System.setErr(PrintStream(parserErr))
+
+        try {
+            assertThrows(org.xml.sax.SAXParseException::class.java) {
+                GpxMarkerImporter().import(ByteArrayInputStream(gpx.toByteArray()), 0)
+            }
+        } finally {
+            System.setErr(originalErr)
+        }
+
+        assertEquals("", parserErr.toString(Charsets.UTF_8))
     }
 }

--- a/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
+++ b/app/src/test/java/org/nitri/opentopo/GpxMarkerImportExportTest.kt
@@ -45,4 +45,19 @@ class GpxMarkerImportExportTest {
         assertEquals("Desc 1", result.markers[0].description)
         assertEquals("Marker 12", result.markers[1].name)
     }
+
+    @Test(expected = org.xml.sax.SAXParseException::class)
+    fun importMarkers_rejectsDoctypeToPreventXxe() {
+        val gpx = """
+            <?xml version="1.0"?>
+            <!DOCTYPE gpx [
+              <!ENTITY xxe SYSTEM "file:///etc/passwd">
+            ]>
+            <gpx version="1.1" creator="test">
+              <wpt lat="51.123" lon="6.456"><name>&xxe;</name></wpt>
+            </gpx>
+        """.trimIndent()
+
+        GpxMarkerImporter().import(ByteArrayInputStream(gpx.toByteArray()), 0)
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent XML External Entity (XXE) and related attacks when importing GPX files by securing the XML parser used by `GpxMarkerImporter`.

### Description

- Replace direct `DocumentBuilderFactory.newInstance()` usage with a `createSecureDocumentBuilderFactory()` that enables secure processing and disables DOCTYPE, external entities, external DTD/schema loading, XInclude, and entity expansion.  
- Apply `XMLConstants` attributes `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_SCHEMA` with empty values to block external resource access.  
- Keep existing waypoint parsing logic and fallback naming behavior unchanged while using the hardened factory.  
- Add a unit test `importMarkers_rejectsDoctypeToPreventXxe` to assert that DOCTYPE declarations (and thus XXE attempts) are rejected with a `SAXParseException`.

### Testing

- Ran `GpxMarkerImportExportTest` which includes `importMarkers_readsValidWaypointsAndSkipsInvalid` and the new `importMarkers_rejectsDoctypeToPreventXxe`, and all tests passed.  
- The import behavior for valid waypoints remains verified by existing tests and continued to succeed.  
- The new test confirms that XML with a DOCTYPE/external entity is blocked by the secure parser and raises `org.xml.sax.SAXParseException` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155a02388c8327bf49f0bb5a973037)