### PR TITLE
Fix marker list edge-to-edge insets

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,6 +13,11 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -45,6 +51,7 @@ class MarkerListActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_marker_list)
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
@@ -54,6 +61,7 @@ class MarkerListActivity : AppCompatActivity() {
 
         recyclerView = findViewById(R.id.markerRecyclerView)
         emptyView = findViewById(R.id.emptyView)
+        applyEdgeToEdgeInsets(toolbar)
 
         adapter = MarkerListAdapter(
             onClick = { marker ->
@@ -86,6 +94,26 @@ class MarkerListActivity : AppCompatActivity() {
                 updateSelectionUi()
             }
         }
+    }
+
+    private fun applyEdgeToEdgeInsets(toolbar: Toolbar) {
+        val root = findViewById<View>(R.id.markerListRoot)
+        val initialToolbarHeight = toolbar.layoutParams.height
+        val initialToolbarPaddingTop = toolbar.paddingTop
+        val initialRecyclerPaddingBottom = recyclerView.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { _, insets ->
+            val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            toolbar.updatePadding(top = initialToolbarPaddingTop + systemBarsInsets.top)
+            toolbar.updateLayoutParams<ViewGroup.LayoutParams> {
+                height = initialToolbarHeight + systemBarsInsets.top
+            }
+            recyclerView.updatePadding(bottom = initialRecyclerPaddingBottom + systemBarsInsets.bottom)
+
+            insets
+        }
+        ViewCompat.requestApplyInsets(root)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/res/layout/activity_marker_list.xml
+++ b/app/src/main/res/layout/activity_marker_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/markerListRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -23,5 +24,6 @@
         android:id="@+id/markerRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:clipToPadding="false" />
 </LinearLayout>


### PR DESCRIPTION
### Motivation
- On newer Android versions the top system bar can overlap the activity action bar and list content, causing UI elements to be obscured. 
- Marker list needed to match other activities that handle edge-to-edge drawing and apply system-bar insets correctly so the toolbar and content are laid out under system bars without overlap.

### Description
- Opt the activity into edge-to-edge by calling `WindowCompat.setDecorFitsSystemWindows(window, false)` in `MarkerListActivity.onCreate` and added the corresponding imports. 
- Add a root id (`@+id/markerListRoot`) to `activity_marker_list.xml` and set the `RecyclerView` `clipToPadding="false"` so content can scroll into padded areas. 
- Implement `applyEdgeToEdgeInsets(toolbar)` in `MarkerListActivity` which uses `ViewCompat.setOnApplyWindowInsetsListener` and `WindowInsetsCompat.Type.systemBars()` to add the top inset to the toolbar (padding and height) and the bottom inset to the recycler view padding, and request insets application.
- Modified files: `app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt` and `app/src/main/res/layout/activity_marker_list.xml`.

### Testing
- Ran `git diff --check` which produced no local diff-check warnings. 
- Attempted to run unit tests with `./gradlew testFossDebugUnitTest`, but the build failed because the Android SDK location is not configured in this environment (missing `ANDROID_HOME` / `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec58a1d088327ab939cb8779f0af3)