### PR TITLE
Fix bulk marker delete dialog spacing

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -217,7 +218,11 @@ class MarkerListActivity : AppCompatActivity() {
                 actionMode?.finish()
             }
             .setNegativeButton(R.string.cancel, null)
-            .show()
+            .create()
+            .also {
+                it.requestWindowFeature(Window.FEATURE_NO_TITLE)
+                it.show()
+            }
     }
 
     private fun exportSelectedMarkers(uri: Uri) {


### PR DESCRIPTION
### Motivation
- The bulk-delete confirmation dialog displayed extra top whitespace compared to the single-marker delete dialog, so the multi-delete dialog needs to match the single-delete presentation.

### Description
- Create the multi-delete `AlertDialog` explicitly and request `Window.FEATURE_NO_TITLE` before `show()`, and add `import android.view.Window` so the bulk-delete dialog uses the same no-title styling as the single-delete flow (`app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt`).

### Testing
- Ran `git diff --check` which passed, then attempted `./gradlew testDebugUnitTest` (failed due to ambiguous task names) and `./gradlew :app:testFossDebugUnitTest` (could not run because Android SDK location is not configured via `ANDROID_HOME` or `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecbba282083279b8945bbe3e52060)