### PR TITLE
Add flavor-safe Firebase analytics reporting

### DIFF
--- a/app/src/foss/java/org/nitri/opentopo/analytics/AnalyticsProvider.kt
+++ b/app/src/foss/java/org/nitri/opentopo/analytics/AnalyticsProvider.kt
@@ -1,26 +1,11 @@
 package org.nitri.opentopo.analytics
 
 import android.content.Context
-import io.ticofab.androidgpxparser.parser.domain.Gpx
 
 /**
  * FOSS flavor provider that returns a no-op tracker.
  */
 object AnalyticsProvider {
-    private var instance: AnalyticsTracker? = null
-
     @Synchronized
-    fun get(context: Context? = null): AnalyticsTracker {
-        if (instance == null) {
-            instance = object : AnalyticsTracker {
-                override fun trackGpxLoaded(source: String, gpx: Gpx, fileName: String?) {
-                    // no-op in FOSS flavor
-                }
-                override fun trackRouteCalculated(profile: String?, waypointCount: Int) {
-                    // no-op in FOSS flavor
-                }
-            }
-        }
-        return instance as AnalyticsTracker
-    }
+    fun get(context: Context? = null): AnalyticsTracker = NoOpAnalyticsTracker
 }

--- a/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/BaseMainActivity.kt
@@ -45,6 +45,7 @@ import org.nitri.opentopo.SettingsActivity.Companion.PREF_FULLSCREEN
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_FULLSCREEN_ON_MAP_TAP
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_KEEP_SCREEN_ON
 import org.nitri.opentopo.SettingsActivity.Companion.PREF_ORS_API_KEY
+import org.nitri.opentopo.analytics.AnalyticsNames
 import org.nitri.opentopo.analytics.AnalyticsProvider
 import org.nitri.opentopo.nearby.NearbyFragment
 import org.nitri.opentopo.nearby.entity.NearbyItem
@@ -304,6 +305,10 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
             supportFragmentManager.beginTransaction()
                 .replace(R.id.map_container, it, MAP_FRAGMENT_TAG)
                 .commit()
+            AnalyticsProvider.get(this).trackScreen(
+                AnalyticsNames.Screen.MAP,
+                MapFragment::class.java.simpleName
+            )
         }
     }
 
@@ -317,6 +322,10 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         supportFragmentManager.beginTransaction().addToBackStack("gpx")
             .replace(R.id.map_container, gpxDetailFragment, GPX_DETAIL_FRAGMENT_TAG)
             .commit()
+        AnalyticsProvider.get(this).trackScreen(
+            AnalyticsNames.Screen.GPX_DETAIL,
+            GpxDetailFragment::class.java.simpleName
+        )
     }
 
     override fun addNearbyFragment(nearbyCenterPoint: GeoPoint) {
@@ -325,6 +334,10 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         supportFragmentManager.beginTransaction().addToBackStack("nearby")
             .replace(R.id.map_container, nearbyFragment, NEARBY_FRAGMENT_TAG)
             .commit()
+        AnalyticsProvider.get(this).trackScreen(
+            AnalyticsNames.Screen.NEARBY,
+            NearbyFragment::class.java.simpleName
+        )
     }
 
     override fun onRequestPermissionsResult(
@@ -503,6 +516,19 @@ open class BaseMainActivity : AppCompatActivity(), MapFragment.OnFragmentInterac
         (supportFragmentManager.findFragmentByTag(MAP_FRAGMENT_TAG) as? MapFragment)?.setKml(kmlDocument, shouldZoomToKml)
         kmlViewModel.kmlDocument = kmlDocument
         kmlUriString?.let { kmlViewModel.kmlUriString = it }
+        val fileName = try {
+            kmlUriString?.toUri()?.lastPathSegment
+        } catch (e: Exception) { null }
+        val contentType = if (kmlUriString?.lowercase()?.endsWith(".kmz") == true) {
+            AnalyticsNames.ContentType.KMZ
+        } else {
+            AnalyticsNames.ContentType.KML
+        }
+        AnalyticsProvider.get(this).trackKmlLoaded(
+            source = "file",
+            contentType = contentType,
+            fileName = fileName
+        )
         shouldZoomToKml = false
     }
 

--- a/app/src/main/java/org/nitri/opentopo/CacheSettingsFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/CacheSettingsFragment.kt
@@ -21,6 +21,8 @@ import org.osmdroid.config.Configuration
 import org.nitri.opentopo.util.Utils
 import java.io.File
 import androidx.core.content.edit
+import org.nitri.opentopo.analytics.AnalyticsNames
+import org.nitri.opentopo.analytics.AnalyticsProvider
 
 
 class CacheSettingsFragment : DialogFragment() {
@@ -30,6 +32,10 @@ class CacheSettingsFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val fragmentActivity = activity ?: return super.onCreateDialog(savedInstanceState)
+        AnalyticsProvider.get(fragmentActivity).trackScreen(
+            AnalyticsNames.Screen.CACHE_SETTINGS,
+            CacheSettingsFragment::class.java.simpleName
+        )
         val fragmentContext = context ?: fragmentActivity
         val builder = AlertDialog.Builder(fragmentActivity)
         val inflater = fragmentActivity.layoutInflater

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -1103,10 +1103,34 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             }
             sharedPreferences.edit { putInt(PREF_BASE_MAP, baseMap) }
             sharedPreferences.edit { putInt(PREF_OVERLAY, overlay) }
+            AnalyticsProvider.get(requireContext()).trackMapLayerSelected(
+                baseMap = baseMapAnalyticsName(baseMap),
+                overlay = overlayAnalyticsName(overlay)
+            )
             setBaseMap()
             setTilesOverlay()
         }
         return true
+    }
+
+
+    private fun baseMapAnalyticsName(baseMap: Int): String {
+        return when (baseMap) {
+            BASE_MAP_OTM -> "open_topo_map"
+            BASE_MAP_OSM -> "open_street_map"
+            BASE_MAP_OHM -> "open_hiking_map"
+            BASE_MAP_FREEMAP_SK -> "freemap_sk"
+            else -> "unknown"
+        }
+    }
+
+    private fun overlayAnalyticsName(overlay: Int): String {
+        return when (overlay) {
+            OverlayHelper.OVERLAY_NONE -> "none"
+            OverlayHelper.OVERLAY_HIKING -> "hiking"
+            OverlayHelper.OVERLAY_CYCLING -> "cycling"
+            else -> "unknown"
+        }
     }
 
     override fun onLocationChanged(location: Location) {

--- a/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
@@ -24,6 +24,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import org.nitri.opentopo.adapter.MarkerListAdapter
+import org.nitri.opentopo.analytics.AnalyticsNames
+import org.nitri.opentopo.analytics.AnalyticsProvider
 import org.nitri.opentopo.model.MarkerModel
 import org.nitri.opentopo.util.GpxMarkerExporter
 import org.nitri.opentopo.util.GpxMarkerImporter
@@ -59,6 +61,10 @@ class MarkerListActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = getString(R.string.markers)
+        AnalyticsProvider.get(this).trackScreen(
+            AnalyticsNames.Screen.MARKERS,
+            MarkerListActivity::class.java.simpleName
+        )
 
         recyclerView = findViewById(R.id.markerRecyclerView)
         emptyView = findViewById(R.id.emptyView)
@@ -205,7 +211,10 @@ class MarkerListActivity : AppCompatActivity() {
             context = this,
             markerModel = marker.copy(),
             onUpdate = { updated -> markerViewModel.updateMarker(updated) },
-            onDelete = { toDelete -> markerViewModel.removeMarker(toDelete.id) }
+            onDelete = { toDelete ->
+                markerViewModel.removeMarker(toDelete.id)
+                AnalyticsProvider.get(this).trackMarkersDeleted(1)
+            }
         )
     }
 
@@ -214,7 +223,9 @@ class MarkerListActivity : AppCompatActivity() {
             .setTitle(getString(R.string.confirm_delete))
             .setMessage(getString(R.string.delete_selected_markers_message, selectedMarkerIds.size))
             .setPositiveButton(R.string.delete) { _, _ ->
+                val deletedCount = selectedMarkerIds.size
                 markerViewModel.removeMarkers(selectedMarkerIds.toList())
+                AnalyticsProvider.get(this@MarkerListActivity).trackMarkersDeleted(deletedCount)
                 actionMode?.finish()
             }
             .setNegativeButton(R.string.cancel, null)
@@ -238,6 +249,7 @@ class MarkerListActivity : AppCompatActivity() {
                     GpxMarkerExporter().export(markersToExport, outputStream)
                 } ?: error("Output stream unavailable")
             }.onSuccess {
+                AnalyticsProvider.get(this@MarkerListActivity).trackMarkersExported(markersToExport.size)
                 Toast.makeText(this@MarkerListActivity, R.string.markers_export_success, Toast.LENGTH_SHORT).show()
             }.onFailure {
                 Toast.makeText(this@MarkerListActivity, R.string.markers_export_failed, Toast.LENGTH_SHORT).show()
@@ -263,6 +275,10 @@ class MarkerListActivity : AppCompatActivity() {
                 }
 
                 markerViewModel.addMarkers(result.markers)
+                AnalyticsProvider.get(this@MarkerListActivity).trackMarkersImported(
+                    importedCount = result.markers.size,
+                    skippedCount = result.skippedCount
+                )
                 if (result.skippedCount > 0) {
                     Toast.makeText(
                         this@MarkerListActivity,

--- a/app/src/main/java/org/nitri/opentopo/SettingsActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/SettingsActivity.kt
@@ -24,6 +24,8 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.launch
+import org.nitri.opentopo.analytics.AnalyticsNames
+import org.nitri.opentopo.analytics.AnalyticsProvider
 import org.nitri.opentopo.util.Utils
 import org.nitri.opentopo.util.importOpenTopoMapZipToSqliteCache
 
@@ -32,6 +34,10 @@ class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.settings_activity)
+        AnalyticsProvider.get(this).trackScreen(
+            AnalyticsNames.Screen.SETTINGS,
+            SettingsActivity::class.java.simpleName
+        )
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         toolbar.setTitleTextColor(ContextCompat.getColor(this, android.R.color.white))

--- a/app/src/main/java/org/nitri/opentopo/analytics/AnalyticsNames.kt
+++ b/app/src/main/java/org/nitri/opentopo/analytics/AnalyticsNames.kt
@@ -1,0 +1,23 @@
+package org.nitri.opentopo.analytics
+
+/**
+ * Shared analytics vocabulary. Main source set code only depends on this
+ * interface layer; flavor source sets decide whether anything is sent.
+ */
+object AnalyticsNames {
+    object Screen {
+        const val MAP = "map"
+        const val GPX_DETAIL = "gpx_detail"
+        const val NEARBY = "nearby"
+        const val MARKERS = "markers"
+        const val SETTINGS = "settings"
+        const val CACHE_SETTINGS = "cache_settings"
+    }
+
+    object ContentType {
+        const val GPX = "gpx"
+        const val KML = "kml"
+        const val KMZ = "kmz"
+        const val MARKERS = "markers"
+    }
+}

--- a/app/src/main/java/org/nitri/opentopo/analytics/AnalyticsTracker.kt
+++ b/app/src/main/java/org/nitri/opentopo/analytics/AnalyticsTracker.kt
@@ -7,9 +7,17 @@ import io.ticofab.androidgpxparser.parser.domain.Gpx
  * and Play flavor can provide a Firebase-backed implementation.
  */
 interface AnalyticsTracker {
+    fun trackScreen(screenName: String, screenClass: String)
+
     fun trackGpxLoaded(
         source: String, // e.g., "file" or other sources
         gpx: Gpx,
+        fileName: String?
+    )
+
+    fun trackKmlLoaded(
+        source: String,
+        contentType: String,
         fileName: String?
     )
 
@@ -17,11 +25,24 @@ interface AnalyticsTracker {
         profile: String?,
         waypointCount: Int
     )
+
+    fun trackMapLayerSelected(baseMap: String, overlay: String)
+
+    fun trackMarkersImported(importedCount: Int, skippedCount: Int)
+
+    fun trackMarkersExported(markerCount: Int)
+
+    fun trackMarkersDeleted(markerCount: Int)
 }
 
 /** No-op implementation used by non-Play builds. */
-private object NoOpAnalyticsTracker : AnalyticsTracker {
+object NoOpAnalyticsTracker : AnalyticsTracker {
+    override fun trackScreen(screenName: String, screenClass: String) { /* no-op */ }
     override fun trackGpxLoaded(source: String, gpx: Gpx, fileName: String?) { /* no-op */ }
+    override fun trackKmlLoaded(source: String, contentType: String, fileName: String?) { /* no-op */ }
     override fun trackRouteCalculated(profile: String?, waypointCount: Int) { /* no-op */ }
+    override fun trackMapLayerSelected(baseMap: String, overlay: String) { /* no-op */ }
+    override fun trackMarkersImported(importedCount: Int, skippedCount: Int) { /* no-op */ }
+    override fun trackMarkersExported(markerCount: Int) { /* no-op */ }
+    override fun trackMarkersDeleted(markerCount: Int) { /* no-op */ }
 }
-

--- a/app/src/play/java/org/nitri/opentopo/analytics/FirebaseAnalyticsTracker.kt
+++ b/app/src/play/java/org/nitri/opentopo/analytics/FirebaseAnalyticsTracker.kt
@@ -6,11 +6,24 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import io.ticofab.androidgpxparser.parser.domain.Gpx
 
 private const val EVENT_GPX_LOADED = "gpx_loaded"
+private const val EVENT_KML_LOADED = "kml_loaded"
 private const val EVENT_ROUTE_CALCULATED = "route_calculated"
+private const val EVENT_MAP_LAYER_SELECTED = "map_layer_selected"
+private const val EVENT_MARKERS_IMPORTED = "markers_imported"
+private const val EVENT_MARKERS_EXPORTED = "markers_exported"
+private const val EVENT_MARKERS_DELETED = "markers_deleted"
 
 class FirebaseAnalyticsTracker(context: Context) : AnalyticsTracker {
 
     private val firebase = FirebaseAnalytics.getInstance(context)
+
+    override fun trackScreen(screenName: String, screenClass: String) {
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
+            putString(FirebaseAnalytics.Param.SCREEN_CLASS, screenClass)
+        }
+        firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, params)
+    }
 
     override fun trackGpxLoaded(source: String, gpx: Gpx, fileName: String?) {
         val params = Bundle().apply {
@@ -23,11 +36,53 @@ class FirebaseAnalyticsTracker(context: Context) : AnalyticsTracker {
         firebase.logEvent(EVENT_GPX_LOADED, params)
     }
 
+    override fun trackKmlLoaded(source: String, contentType: String, fileName: String?) {
+        val params = Bundle().apply {
+            putString("source", source)
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, contentType)
+            fileName?.let { putString("file_name", it) }
+        }
+        firebase.logEvent(EVENT_KML_LOADED, params)
+    }
+
     override fun trackRouteCalculated(profile: String?, waypointCount: Int) {
         val params = Bundle().apply {
             profile?.let { putString("profile", it) }
             putInt("waypoint_count", waypointCount)
         }
         firebase.logEvent(EVENT_ROUTE_CALCULATED, params)
+    }
+
+    override fun trackMapLayerSelected(baseMap: String, overlay: String) {
+        val params = Bundle().apply {
+            putString("base_map", baseMap)
+            putString("overlay", overlay)
+        }
+        firebase.logEvent(EVENT_MAP_LAYER_SELECTED, params)
+    }
+
+    override fun trackMarkersImported(importedCount: Int, skippedCount: Int) {
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, AnalyticsNames.ContentType.MARKERS)
+            putInt("imported_count", importedCount)
+            putInt("skipped_count", skippedCount)
+        }
+        firebase.logEvent(EVENT_MARKERS_IMPORTED, params)
+    }
+
+    override fun trackMarkersExported(markerCount: Int) {
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, AnalyticsNames.ContentType.MARKERS)
+            putInt("marker_count", markerCount)
+        }
+        firebase.logEvent(EVENT_MARKERS_EXPORTED, params)
+    }
+
+    override fun trackMarkersDeleted(markerCount: Int) {
+        val params = Bundle().apply {
+            putString(FirebaseAnalytics.Param.CONTENT_TYPE, AnalyticsNames.ContentType.MARKERS)
+            putInt("marker_count", markerCount)
+        }
+        firebase.logEvent(EVENT_MARKERS_DELETED, params)
     }
 }


### PR DESCRIPTION
### Motivation
- Provide structured analytics for the Play distribution while keeping the FOSS distribution free of proprietary telemetry by introducing a flavor-safe analytics abstraction.
- Capture major screen views and a set of useful events (GPX/KML loads, route calculations, map layer changes, marker import/export/delete) for product insight on Play without changing FOSS behavior.

### Description
- Add a shared vocabulary in `AnalyticsNames` and expand the `AnalyticsTracker` interface with screen reporting and event hooks for KML, map-layer, and marker import/export/delete in `app/src/main/java/org/nitri/opentopo/analytics/`.
- Keep FOSS flavor telemetry inert by returning the shared `NoOpAnalyticsTracker` from `app/src/foss/java/org/nitri/opentopo/analytics/AnalyticsProvider.kt` so main-code calls remain safe in FOSS builds.
- Implement Firebase-backed reporting in the Play flavor in `app/src/play/java/org/nitri/opentopo/analytics/FirebaseAnalyticsTracker.kt` and keep Play-only dependencies behind `playImplementation` in `app/build.gradle`.
- Wire analytics calls into runtime places: screen views in `BaseMainActivity`, settings and cache settings, KML/GPX load hooks, route calculation in `MapFragment`, map layer selection reporting in `MapFragment`, and marker import/export/delete and screen view in `MarkerListActivity`.

### Testing
- Ran `git diff --check` with no whitespace or diff-check issues detected (passed). 
- Ran `./gradlew :app:dependencies --configuration fossDebugRuntimeClasspath --no-daemon` and `./gradlew :app:dependencies --configuration playDebugRuntimeClasspath --no-daemon` to validate dependency wiring for both flavors (both succeeded). 
- Attempted `./gradlew :app:assembleFossDebug --no-daemon` but it was blocked by the environment missing Android SDK configuration (`ANDROID_HOME` / `local.properties`); this prevented a full build in this environment. 
- Changes were committed and prepared as the PR titled `Add flavor-safe Firebase analytics reporting`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25572f11a083278789ffc25140cfcc)