### PR TITLE
Add XML bitmap aliases for osmdroid location drawables

### DIFF
--- a/app/src/main/res/drawable/person.xml
+++ b/app/src/main/res/drawable/person.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    osmdroid's MyLocationNewOverlay loads a drawable named "person" in its
+    constructor before OpenTopoMapViewer replaces it with ic_position.
+    Keep this as a text XML bitmap alias so the default lookup succeeds
+    without adding generated binary assets to the repository.
+-->
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/ic_default_marker"
+    android:gravity="center" />

--- a/app/src/main/res/drawable/round_navigation_white_48.xml
+++ b/app/src/main/res/drawable/round_navigation_white_48.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    osmdroid's MyLocationNewOverlay loads a drawable named
+    "round_navigation_white_48" in its constructor before OpenTopoMapViewer
+    replaces it with ic_direction. This XML bitmap alias avoids committing
+    binary fallback resources while still inflating as a BitmapDrawable.
+-->
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/ic_default_marker"
+    android:gravity="center" />


### PR DESCRIPTION
### Motivation
- Provide XML bitmap aliases for the drawables `person` and `round_navigation_white_48` so osmdroid's `MyLocationNewOverlay` can find them at construction time without adding generated binary assets to the repository.

### Description
- Add `res/drawable/person.xml` and `res/drawable/round_navigation_white_48.xml` as bitmap aliases that reference `@drawable/ic_default_marker` with `android:gravity="center"` and include comments explaining their purpose.

### Testing
- Ran `./gradlew assembleDebug` and `./gradlew lint` to validate resource merging and inflation; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34f4290fc88327b1e50bed4d29148c)