### PR TITLE
Fix marker deletion confirmation crash

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
@@ -115,18 +115,21 @@ class MarkerEditorDialog : DialogFragment() {
     }
 
     private fun showDeleteConfirmation(markerId: Int) {
+        // Selecting the editor's neutral button dismisses its AlertDialog, which can detach this
+        // DialogFragment before the confirmation dialog's button callback runs.
+        val fragmentManager = parentFragmentManager
+
         AlertDialog.Builder(requireContext())
             .setTitle(R.string.confirm_delete)
             .setMessage(R.string.prompt_confirm_delete)
             .setPositiveButton(R.string.delete) { _, _ ->
-                setFragmentResult(
+                fragmentManager.setFragmentResult(
                     RESULT_REQUEST_KEY,
                     Bundle().apply {
                         putString(RESULT_ACTION, RESULT_ACTION_DELETE)
                         putInt(RESULT_MARKER_ID, markerId)
                     }
                 )
-                dismiss()
             }
             .setNegativeButton(R.string.cancel, null)
             .create()


### PR DESCRIPTION
### Motivation
- Prevent a crash when confirming marker deletion from the editor dialog caused by calling `setFragmentResult` on a `DialogFragment` that may have been detached by the neutral button action.

### Description
- Capture `parentFragmentManager` into a local `fragmentManager` before showing the delete confirmation and use it to deliver the delete result instead of calling `setFragmentResult` on the (possibly detached) fragment, and avoid dismissing the editor from the confirmation callback.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted `./gradlew :app:testFossDebugUnitTest` but it could not run due to the Android SDK not being configured in the environment (missing `ANDROID_HOME` / `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca5f134b88327a852abb2af951b1d)