### PR TITLE
Increase Gradle daemon heap to 4g for Android release builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# D8 and Android lint run during release packaging and exceed the default heap on
+# this project's dependency graph. Keep enough headroom for both in the Gradle
+# daemon rather than failing during dex archive merging.
+org.gradle.jvmargs=-Xmx4g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
### Motivation
- D8 (dex merging) and Android lint can exhaust the default Gradle JVM heap during release packaging, causing OOM failures; increase the daemon heap to prevent dex-merge/lint failures.

### Description
- Update `gradle.properties` to set `org.gradle.jvmargs=-Xmx4g` and add an inline rationale explaining the increased heap requirement.

### Testing
- Ran `./gradlew help --no-configuration-cache --warning-mode all`, which completed successfully.
- Confirmed the started Gradle daemon received `-Xmx4g` by inspecting the daemon logs, which shows the new JVM arg.
- Attempted `./gradlew :app:assembleFossRelease` but it could not run in this environment because the Android SDK is not configured (`ANDROID_HOME`/`local.properties`), so the full release build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cb0f41f1083278a564c6a4dae6797)