### PR TITLE
Fail-closed FOSS release signing: validate secrets, keystore and verify APK signer

### DIFF
--- a/.github/workflows/android-foss-release.yml
+++ b/.github/workflows/android-foss-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENABLE_PLAY_RELEASE: "false"
-      STORE_FILE: keystore
+      STORE_FILE: keystore.jks
       STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
       KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
       KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -32,8 +32,41 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Validate signing secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64" || { echo "::error::ANDROID_KEYSTORE_BASE64 is missing"; exit 1; }
+          test -n "$STORE_PASSWORD" || { echo "::error::STORE_PASSWORD is missing"; exit 1; }
+          test -n "$KEY_ALIAS" || { echo "::error::KEY_ALIAS is missing"; exit 1; }
+          test -n "$KEY_PASSWORD" || { echo "::error::KEY_PASSWORD is missing"; exit 1; }
+
       - name: Restore signing key from secret
-        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > keystore.jks
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$STORE_FILE"
+          test -s "$STORE_FILE" || { echo "::error::Restored keystore is empty"; exit 1; }
+
+      - name: Validate signing key
+        run: |
+          KEYSTORE_DETAILS="$(LC_ALL=C keytool -list -v \
+            -keystore "$STORE_FILE" \
+            -storepass:env STORE_PASSWORD \
+            -alias "$KEY_ALIAS")" || {
+              echo "::error::Unable to open the keystore or find KEY_ALIAS"
+              exit 1
+            }
+          EXPECTED_SIGNER_SHA256="$(printf '%s\n' "$KEYSTORE_DETAILS" \
+            | awk -F': ' '/SHA256:/{print $2; exit}' \
+            | tr -d ':[:space:]' \
+            | tr '[:lower:]' '[:upper:]')"
+          test -n "$EXPECTED_SIGNER_SHA256" || {
+            echo "::error::Unable to determine the signing certificate SHA-256 digest"
+            exit 1
+          }
+          echo "Expected signer SHA-256: $EXPECTED_SIGNER_SHA256"
+          echo "EXPECTED_SIGNER_SHA256=$EXPECTED_SIGNER_SHA256" >> "$GITHUB_ENV"
 
       # Build signed release (your build.gradle wires signing from env vars)
       - name: Build FOSS release (APK + AAB)
@@ -45,6 +78,41 @@ jobs:
             :app:assembleFossRelease \
             :app:bundleFossRelease \
             --warning-mode all --stacktrace
+
+      - name: Verify FOSS release APK signature
+        run: |
+          APK="app/build/outputs/apk/foss/release/app-foss-release.apk"
+          test -s "$APK" || { echo "::error::Release APK was not produced"; exit 1; }
+
+          APKSIGNER="$(find "$ANDROID_HOME/build-tools" -type f -name apksigner -print \
+            | sort -V | tail -n 1)"
+          test -x "$APKSIGNER" || { echo "::error::Android SDK apksigner was not found"; exit 1; }
+
+          SIGNER_DETAILS="$("$APKSIGNER" verify --print-certs "$APK")" || {
+            echo "::error::APK signature verification failed"
+            exit 1
+          }
+          printf '%s\n' "$SIGNER_DETAILS"
+
+          if printf '%s\n' "$SIGNER_DETAILS" | grep -Eiq \
+            'CN[[:space:]]*=[[:space:]]*Android Debug|c07faa269db3e4c58abe2d869b48bc723f99cbd1'; then
+            echo "::error::The release APK is signed with the standard Android debug certificate"
+            exit 1
+          fi
+
+          ACTUAL_SIGNER_SHA256="$(printf '%s\n' "$SIGNER_DETAILS" \
+            | awk -F': ' '/Signer #1 certificate SHA-256 digest:/{print $2; exit}' \
+            | tr -d ':[:space:]' \
+            | tr '[:lower:]' '[:upper:]')"
+          test -n "$ACTUAL_SIGNER_SHA256" || {
+            echo "::error::apksigner did not report a signer SHA-256 digest"
+            exit 1
+          }
+          test "$ACTUAL_SIGNER_SHA256" = "$EXPECTED_SIGNER_SHA256" || {
+            echo "::error::APK signer does not match the configured release key"
+            exit 1
+          }
+          echo "Verified APK signer SHA-256: $ACTUAL_SIGNER_SHA256"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,6 @@ android {
         release {
             minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig = signingConfigs.debug
             if (myStoreFile && myStorePassword && myKeyAlias && myKeyPassword) {
                 signingConfig = signingConfigs.release
             }


### PR DESCRIPTION
### Motivation

- Ensure GitHub FOSS releases cannot silently fall back to the Android debug key and fail early when signing secrets are missing. 
- Make the keystore path consistent between the workflow and Gradle and add explicit pre- and post-build checks to guarantee the produced APK is signed with the expected release key.

### Description

- Update the workflow to use a consistent keystore filename by setting `STORE_FILE: keystore.jks` in `.github/workflows/android-foss-release.yml` and write/read the keystore via `$STORE_FILE`.
- Add a preflight step `Validate signing secrets` that fails fast if any of `ANDROID_KEYSTORE_BASE64`, `STORE_PASSWORD`, `KEY_ALIAS`, or `KEY_PASSWORD` are missing, without echoing secrets.
- Restore the keystore with `printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$STORE_FILE"` and verify the restored file exists and is non-empty. 
- Validate the keystore with `keytool -list -v` using the configured `STORE_PASSWORD` and `KEY_ALIAS`, extract the signing certificate SHA-256 fingerprint, and expose it as `EXPECTED_SIGNER_SHA256` via `GITHUB_ENV` for later comparison.
- Remove the silent debug-signing fallback in `app/build.gradle` by deleting `signingConfig = signingConfigs.debug` so the `release` build only uses `signingConfigs.release` when all release signing inputs are present.
- After `:app:assembleFossRelease`, run `apksigner verify --print-certs` on `app/build/outputs/apk/foss/release/app-foss-release.apk`, fail if signer DN contains `CN=Android Debug` or the known Android debug digest, and compare the APK signer SHA-256 digest to the fingerprint derived from the restored keystore to ensure an exact match before uploading or publishing artifacts.
- Keep artifact upload and GitHub Release creation strictly after signature verification and preserve existing FOSS/Play flavor and release behaviors, including `ENABLE_PLAY_RELEASE=false` and generated release notes.
- Assumptions: the repository provides the four secrets under the names `ANDROID_KEYSTORE_BASE64`, `STORE_PASSWORD`, `KEY_ALIAS`, and `KEY_PASSWORD`, and the runner has a usable Android SDK with `apksigner` available via `ANDROID_HOME/build-tools`.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff errors and it succeeded.
- Parsed the workflow YAML with `ruby -e "require 'yaml'; ..."` to assert `STORE_FILE` equals `keystore.jks` and that check succeeded.
- Verified Gradle exposes the `assembleFossRelease` task by running `./gradlew :app:tasks --all` and searching the task list, which succeeded.
- `actionlint` was not available in the environment so the workflow lint step was not run, and a full signed build plus `apksigner` verification was not executed because repository signing secrets and keystore are intentionally unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8034314ac883278cee48bff555e76f)