### PR TITLE
Robust apksigner SHA-256 extraction for varying signer labels

### DIFF
--- a/.github/workflows/android-foss-release.yml
+++ b/.github/workflows/android-foss-release.yml
@@ -101,7 +101,7 @@ jobs:
           fi
 
           ACTUAL_SIGNER_SHA256="$(printf '%s\n' "$SIGNER_DETAILS" \
-            | awk -F': ' '/Signer #1 certificate SHA-256 digest:/{print $2; exit}' \
+            | awk -F': ' '/certificate SHA-256 digest:/{print $NF; exit}' \
             | tr -d ':[:space:]' \
             | tr '[:lower:]' '[:upper:]')"
           test -n "$ACTUAL_SIGNER_SHA256" || {


### PR DESCRIPTION
### Motivation
- Ensure the APK signature verification extracts the certificate SHA-256 digest regardless of the signer label prefix emitted by `apksigner` (e.g. `V2 Signer`, `Signer #1`, `Source Stamp Signer`).

### Description
- Update `.github/workflows/android-foss-release.yml` to use `awk -F': ' '/certificate SHA-256 digest:/{print $NF; exit}'` so the last colon-separated field is extracted, while preserving the existing `tr -d ':[:space:]'` and `tr '[:lower:]' '[:upper:]'` normalization to produce `ACTUAL_SIGNER_SHA256`.

### Testing
- Ran a shell fixture that validates digest extraction across multiple prefix formats and it passed, and ran `git diff --check` which reported no issues; `actionlint` was unavailable so workflow linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8066e62f18832793a1ab9091aa5362)