### PR TITLE
Add upload-ready signed Google Play release workflow

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -1,0 +1,136 @@
+name: Android Play Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+env:
+  ENABLE_PLAY_RELEASE: "true"
+  STORE_FILE: keystore.jks
+  STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+  KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+  KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+  GPR_USER: ${{ github.actor }}
+  GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Validate release secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64" || { echo "::error::ANDROID_KEYSTORE_BASE64 is missing"; exit 1; }
+          test -n "$STORE_PASSWORD" || { echo "::error::STORE_PASSWORD is missing"; exit 1; }
+          test -n "$KEY_ALIAS" || { echo "::error::KEY_ALIAS is missing"; exit 1; }
+          test -n "$KEY_PASSWORD" || { echo "::error::KEY_PASSWORD is missing"; exit 1; }
+          test -n "$GOOGLE_SERVICES_JSON_BASE64" || { echo "::error::GOOGLE_SERVICES_JSON_BASE64 is missing"; exit 1; }
+
+      - name: Restore and validate signing key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$STORE_FILE"
+          test -s "$STORE_FILE" || { echo "::error::Restored keystore is empty"; exit 1; }
+
+          KEYSTORE_DETAILS="$(LC_ALL=C keytool -list -v \
+            -keystore "$STORE_FILE" \
+            -storepass:env STORE_PASSWORD \
+            -alias "$KEY_ALIAS")" || {
+              echo "::error::Unable to open the keystore or find KEY_ALIAS"
+              exit 1
+            }
+          EXPECTED_SIGNER_SHA256="$(printf '%s\n' "$KEYSTORE_DETAILS" \
+            | awk -F': ' '/SHA256:/{print $2; exit}' \
+            | tr -d ':[:space:]' \
+            | tr '[:lower:]' '[:upper:]')"
+          test -n "$EXPECTED_SIGNER_SHA256" || {
+            echo "::error::Unable to determine the signing certificate SHA-256 digest"
+            exit 1
+          }
+          printf '%s\n' "$KEYSTORE_DETAILS" | awk '/Owner:|SHA256:/{print}'
+          echo "EXPECTED_SIGNER_SHA256=$EXPECTED_SIGNER_SHA256" >> "$GITHUB_ENV"
+
+      - name: Restore and validate Google Services configuration
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          printf '%s' "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/google-services.json
+          test -s app/google-services.json || { echo "::error::Restored google-services.json is empty"; exit 1; }
+          python3 -m json.tool app/google-services.json >/dev/null || {
+            echo "::error::Restored google-services.json is not valid JSON"
+            exit 1
+          }
+
+      - name: Build signed Play release bundle
+        run: |
+          ./gradlew clean \
+            :app:bundlePlayRelease \
+            --warning-mode all --stacktrace
+
+      - name: Locate and verify Play release bundle
+        run: |
+          expected="app/build/outputs/bundle/playRelease/app-play-release.aab"
+          if test -s "$expected"; then
+            AAB="$expected"
+          else
+            mapfile -t candidates < <(find app/build/outputs/bundle/playRelease \
+              -maxdepth 1 -type f -name '*-play-release.aab' -size +0c -print 2>/dev/null)
+            test "${#candidates[@]}" -eq 1 || {
+              echo "::error::Expected exactly one Play release AAB, found ${#candidates[@]}"
+              exit 1
+            }
+            AAB="${candidates[0]}"
+          fi
+
+          jarsigner -verify -verbose -certs "$AAB" || {
+            echo "::error::AAB signature verification failed"
+            exit 1
+          }
+
+          # keytool reads the signer certificate embedded in the signed JAR/AAB.
+          AAB_CERT_DETAILS="$(LC_ALL=C keytool -printcert -jarfile "$AAB")" || {
+            echo "::error::Unable to read the AAB signer certificate"
+            exit 1
+          }
+          ACTUAL_SIGNER_SHA256="$(printf '%s\n' "$AAB_CERT_DETAILS" \
+            | awk -F': ' '/SHA256:/{print $2; exit}' \
+            | tr -d ':[:space:]' \
+            | tr '[:lower:]' '[:upper:]')"
+          test -n "$ACTUAL_SIGNER_SHA256" || {
+            echo "::error::Unable to determine the AAB signer SHA-256 digest"
+            exit 1
+          }
+          test "$ACTUAL_SIGNER_SHA256" = "$EXPECTED_SIGNER_SHA256" || {
+            echo "::error::AAB signer does not match the configured release key"
+            exit 1
+          }
+          echo "Verified AAB signer SHA-256: $ACTUAL_SIGNER_SHA256"
+          echo "AAB_PATH=$AAB" >> "$GITHUB_ENV"
+
+      - name: Upload signed Play release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenTopoMapViewer-play-release
+          path: ${{ env.AAB_PATH }}
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 .aider*
 ./app/src/play/google-services.json.b64
 ./app/src/play/google-services.json
-
+/app/google-services.json
+/keystore.jks

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,12 +68,12 @@ android {
     }
 
     // 🔒 Disable unwanted variants with the modern API (AGP 8+)
-    // 1) On CI: disable *all* Play variants (debug+release)
+    // 1) On CI: disable *all* Play variants unless the dedicated release job opts in
     // 2) Locally: disable Play *release* unless ENABLE_PLAY_RELEASE=true
     androidComponents {
-        // CI: kill every "play" variant
+        // Normal CI does not configure Play; the dedicated Play release job explicitly opts in.
         beforeVariants(selector().withFlavor("distribution", "play")) { v ->
-            if (isCi) {
+            if (isCi && !enablePlayRelease) {
                 v.enabled = false
             }
         }


### PR DESCRIPTION
### Motivation

- Provide a dedicated, manually-dispatchable GitHub Actions workflow that produces a fully signed Google Play AAB ready for manual upload while keeping FOSS and F‑Droid flows unchanged.
- Ensure the Play AAB is signed with the repository-keystore, that the signer is validated by SHA‑256 fingerprint before upload, and that no signing material or `google-services.json` is committed.

### Description

- Add `./.github/workflows/android-play-release.yml` which sets `ENABLE_PLAY_RELEASE=true`, validates required secrets (`ANDROID_KEYSTORE_BASE64`, `STORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, `GOOGLE_SERVICES_JSON_BASE64`), restores `keystore.jks` and `app/google-services.json`, validates the keystore and JSON, builds `:app:bundlePlayRelease`, verifies the AAB with `jarsigner` and extracts the signer certificate with `keytool -printcert -jarfile` to compare a normalized SHA‑256 fingerprint to the keystore-derived `EXPECTED_SIGNER_SHA256`, and uploads only the verified AAB as the `OpenTopoMapViewer-play-release` Actions artifact using `actions/upload-artifact@v4`.
- Change `app/build.gradle` variant gating so Play variants remain disabled on normal CI except when the dedicated workflow explicitly sets `ENABLE_PLAY_RELEASE=true` (replace `if (isCi)` with `if (isCi && !enablePlayRelease)`), preserving local debug and FOSS behaviors.
- Update `.gitignore` to ensure `app/google-services.json` and `keystore.jks` are ignored and never committed.
- The workflow deliberately does not create or attach a GitHub Release and does not perform any Play Console API uploads or deployments.

### Testing

- `git diff --check` completed with no issues.
- Workflow YAML was parsed successfully using Ruby's YAML loader to validate syntax and structure.
- `git check-ignore` confirmed `app/google-services.json` and `keystore.jks` are ignored.
- Synthetic signing test: generated a temporary keystore and a synthetic signed AAB, ran `jarsigner -verify -verbose -certs` and compared `keytool -list -v` fingerprint to `keytool -printcert -jarfile` fingerprint, and the SHA‑256 comparison passed.
- Gradle variant/build verification was attempted, but a full Gradle configuration/build in this environment failed due to external dependency downloads returning HTTP 403, so end‑to‑end Gradle build validation could not complete here (the workflow logic still runs `./gradlew clean :app:bundlePlayRelease` when secrets are present in Actions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a807d869f7c83278e900d6e1600e8c6)