### PR TITLE
Pin AndroidX Core to 1.18.0 to avoid Android 14 WindowInsets crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,8 +114,19 @@ if (isPlayBuild) {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    //noinspection GradleCompatible
-    implementation 'androidx.core:core-ktx:1.19.0'
+    // Core 1.19.0 dispatches WindowInsets.Type.systemOverlays() from its API 34
+    // implementation, although that platform method is unavailable on Android 14.
+    // Keep both artifacts pinned so a transitive dependency cannot reintroduce the
+    // crash while Compose initializes Scaffold's default window insets.
+    implementation('androidx.core:core-ktx:1.18.0') {
+        version { strictly '1.18.0' }
+    }
+    constraints {
+        implementation('androidx.core:core:1.18.0') {
+            version { strictly '1.18.0' }
+            because 'core 1.19.0 crashes on Android 14 when resolving system overlay insets'
+        }
+    }
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.11.0"
     implementation 'androidx.appcompat:appcompat:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.2'


### PR DESCRIPTION
### Motivation

- A `NoSuchMethodError` is observed on Android 14 when Compose initializes window insets because `androidx.core:core-ktx:1.19.0` dispatches `WindowInsets.Type.systemOverlays()` which is not available on that platform. 

### Description

- Replace the `androidx.core:core-ktx` implementation with a pinned `1.18.0` artifact by adding `implementation('androidx.core:core-ktx:1.18.0') { version { strictly '1.18.0' } }` in `app/build.gradle`.
- Add a strict constraint for the underlying `androidx.core:core` artifact with `implementation('androidx.core:core:1.18.0') { version { strictly '1.18.0' } because 'core 1.19.0 crashes on Android 14 when resolving system overlay insets' }` to prevent transitive updates from reintroducing the problem.
- The change is limited to `app/build.gradle` and targets runtime/compose window-inset initialization failure vectors only.

### Testing

- Ran `git diff --check` which reported no whitespace or patch errors and passed. 
- Ran `./gradlew :app:tasks --offline` which completed successfully and enumerated available tasks. 
- Ran dependency resolution checks: a prior `:app:dependencyInsight` run against `androidx.core:core-ktx:1.19.0` returned HTTP 403 when fetching metadata from the remote, and after pinning, `:app:dependencyInsight --offline` failed because `1.18.0` was not present in the local cache (network fetch is blocked in the environment).
- Verified `app/build.gradle` now contains the strict `1.18.0` implementation and constraint to guard against regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8952845c048327ac9bf55205c5ac5d)