### PR TITLE
Remove Compose UI test manifest from debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,7 +177,6 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
 }
 
 tasks.matching { it.name.contains("Crashlytics") }.configureEach {


### PR DESCRIPTION
### Motivation
- Prevent the test-only `InstrumentationActivityInvoker$BootstrapActivity` from being packaged into debug application APKs and possibly resumed outside of an instrumentation test, which can trigger NPE crashes. 

### Description
- Remove the `debugImplementation 'androidx.compose.ui:ui-test-manifest'` line from `app/build.gradle` so Compose inspection tooling remains available while test-only activities are not packaged. 

### Testing
- Ran `git diff --check` which passed. 
- Ran `./gradlew :app:dependencies --configuration fossDebugRuntimeClasspath` and verified the app runtime dependency graph no longer includes `androidx.compose.ui:ui-test-manifest` or `androidx.test:core`. 
- Attempted `./gradlew testFossDebugUnitTest assembleFossDebug --stacktrace` but it could not run in this environment because the Android SDK location is not configured (local `sdk.dir` / `ANDROID_HOME` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a895b11b6d48327a373574188120cd2)