### PR TITLE
Mark HsdpShimActivity non-exported to prevent external HSDP shim launches

### DIFF
--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
 
     <application>
+
+        <!--
+            play-services-ads includes this activity through the HSDP library. HSDP 2.0.1
+            crashes when another app starts it without its private target-package extra, so
+            do not expose the implementation detail outside this application.
+        -->
+        <activity
+            android:name="com.google.android.play.core.hsdp.service.HsdpShimActivity"
+            android:exported="false"
+            tools:replace="android:exported" />
 
         <!-- Sample AdMob app ID: ca-app-pub-3940256099942544~3347511713 -->
         <meta-data


### PR DESCRIPTION
### Motivation
- Prevent the HSDP shim activity from being launched by other apps (which can cause an IllegalStateException when the private `targetPackageName` extra is missing) by ensuring the implementation detail is not exposed from the Play flavor manifest.

### Description
- Add the `tools` namespace and an overridden activity entry for `com.google.android.play.core.hsdp.service.HsdpShimActivity` in `app/src/play/AndroidManifest.xml`, setting `android:exported="false"` with `tools:replace="android:exported"` and an explanatory comment.

### Testing
- Confirmed the updated `app/src/play/AndroidManifest.xml` is well-formed and the activity is present and non-exported using a Python XML parse, ran `git diff --check`, and attempted `./gradlew :app:processPlayDebugMainManifest` which could not complete because dependency resolution failed with HTTP 403 errors from remote Maven repositories in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a895b717b3c8327a7a571f23a6b5341)