### PR TITLE
Keep GPX details clear of landscape system bars

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/GpxDetailFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/GpxDetailFragment.kt
@@ -16,6 +16,8 @@ import android.webkit.WebView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -76,6 +78,19 @@ class GpxDetailFragment : Fragment(), WayPointListAdapter.OnItemClickListener,
         savedInstanceState: Bundle?
     ): View? {
         val rootView = inflater.inflate(R.layout.fragment_gpx_detail, container, false)
+        rootView.post {
+            val windowInsets = ViewCompat.getRootWindowInsets(rootView) ?: return@post
+            val safeInsets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.navigationBars() or
+                        WindowInsetsCompat.Type.displayCutout()
+            )
+            rootView.setPadding(
+                safeInsets.left,
+                rootView.paddingTop,
+                safeInsets.right,
+                rootView.paddingBottom
+            )
+        }
         tvName = rootView.findViewById(R.id.tvTitle)
         tvDescription = rootView.findViewById(R.id.tvDescription)
         wvDescription = rootView.findViewById(R.id.wvDescription)

--- a/app/src/main/res/layout/fragment_gpx_detail.xml
+++ b/app/src/main/res/layout/fragment_gpx_detail.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:fillViewport="true"
     tools:context=".GpxDetailFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <TextView
             android:id="@+id/tvTitle"
@@ -28,27 +28,27 @@
         <FrameLayout
             android:id="@+id/descriptionContainer"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
+            android:layout_height="match_parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
             app:layout_constraintTop_toBottomOf="@+id/tvTitle">
 
-            <TextView
-                android:id="@+id/tvDescription"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="start"
-                tools:text="Description" />
+        <TextView
+            android:id="@+id/tvDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            tools:text="Description" />
 
-            <WebView
-                android:id="@+id/wvDescription"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="start"
-                tools:text="Description" />
+        <WebView
+            android:id="@+id/wvDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            tools:text="Description" />
 
         </FrameLayout>
 
@@ -70,25 +70,29 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvLength">
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvLength"
+            app:layout_constraintVertical_bias="0.0">
 
             <TextView
                 android:id="@+id/caption"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
+                android:layout_marginBottom="0dp"
                 android:text="@string/elevation"
+                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="@+id/elevationChart"
-                app:layout_constraintStart_toStartOf="@id/elevationChart"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintStart_toStartOf="@id/elevationChart" />
 
             <TextView
                 android:id="@+id/xLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
+                android:layout_marginBottom="0dp"
                 android:text="@string/unit_km"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -111,6 +115,7 @@
                 android:id="@+id/elevationChart"
                 android:layout_width="0dp"
                 android:layout_height="160dp"
+                android:layout_marginStart="0dp"
                 android:layout_marginEnd="8dp"
                 app:layout_constraintBottom_toTopOf="@id/xLabel"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -131,6 +136,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/chartContainer" />
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_gpx_detail.xml
+++ b/app/src/main/res/layout/fragment_gpx_detail.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:fillViewport="true"
     tools:context=".GpxDetailFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/tvTitle"
@@ -28,27 +28,27 @@
         <FrameLayout
             android:id="@+id/descriptionContainer"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
             app:layout_constraintTop_toBottomOf="@+id/tvTitle">
 
-        <TextView
-            android:id="@+id/tvDescription"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            tools:text="Description" />
+            <TextView
+                android:id="@+id/tvDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="start"
+                tools:text="Description" />
 
-        <WebView
-            android:id="@+id/wvDescription"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            tools:text="Description" />
+            <WebView
+                android:id="@+id/wvDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="start"
+                tools:text="Description" />
 
         </FrameLayout>
 
@@ -70,29 +70,25 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvLength"
-            app:layout_constraintVertical_bias="0.0">
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvLength">
 
             <TextView
                 android:id="@+id/caption"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
-                android:layout_marginBottom="0dp"
                 android:text="@string/elevation"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="@+id/elevationChart"
-                app:layout_constraintStart_toStartOf="@id/elevationChart" />
+                app:layout_constraintStart_toStartOf="@id/elevationChart"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/xLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
-                android:layout_marginBottom="0dp"
                 android:text="@string/unit_km"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -115,7 +111,6 @@
                 android:id="@+id/elevationChart"
                 android:layout_width="0dp"
                 android:layout_height="160dp"
-                android:layout_marginStart="0dp"
                 android:layout_marginEnd="8dp"
                 app:layout_constraintBottom_toTopOf="@id/xLabel"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -136,7 +131,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/chartContainer" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## Summary
- apply the navigation-bar and display-cutout left/right insets to the GPX detail root view
- keep the existing portrait layout and map behavior unchanged

## Cause
The apparent layout changes depend on which direction the phone is rotated. Android places the landscape navigation bar on the left in one orientation and on the right in the other. `BaseMainActivity` only applies the bottom system-bar inset, so the GPX detail content was drawn beneath a lateral navigation bar and clipped.

## Testing
- compared both supplied screen recordings frame by frame
- confirmed that the clipping swaps sides with the navigation bar
- Android build/device testing still required