### PR TITLE
Migrate GPX discard confirmation to Compose

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -3,7 +3,6 @@ package org.nitri.opentopo
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -24,16 +23,15 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
-import android.view.Window
 import android.view.WindowManager
 import android.widget.PopupMenu
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -59,6 +57,7 @@ import org.nitri.opentopo.util.MapOrientation
 import org.nitri.opentopo.util.OrientationSensor
 import org.nitri.opentopo.util.Utils
 import org.nitri.opentopo.view.AboutDialog
+import org.nitri.opentopo.view.ConfirmationDialogFragment
 import org.nitri.opentopo.view.MarkerEditorDialog
 import org.nitri.opentopo.viewmodel.GpxViewModel
 import org.nitri.opentopo.viewmodel.GpxViewModel.GpxDisplayState
@@ -174,6 +173,34 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
     @Suppress("deprecation")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        childFragmentManager.setFragmentResultListener(
+            GPX_DISCARD_REQUEST_KEY,
+            this
+        ) { _, result ->
+            when (result.getString(GPX_DISCARD_ACTION_KEY)) {
+                GPX_DISCARD_ACTION_REPLACE_CALCULATED -> {
+                    removeGpx()
+                    result.getString(GPX_REPLACEMENT_KEY)?.let { gpx ->
+                        listener?.parseCalculatedGpx(gpx)
+                    }
+                }
+                GPX_DISCARD_ACTION_SELECT_NEW -> {
+                    removeGpx()
+                    markerViewModel.markers.value?.forEach {
+                        it.routeWaypoint = false
+                    }
+                    listener?.clearGpx()
+                    listener?.selectGpx()
+                }
+                GPX_DISCARD_ACTION_REMOVE -> {
+                    removeGpx()
+                    markerViewModel.markers.value?.forEach {
+                        it.routeWaypoint = false
+                    }
+                    listener?.clearGpx()
+                }
+            }
+        }
         mapHandler = Handler(Looper.getMainLooper())
         setHasOptionsMenu(true)
         val hostActivity = activity ?: return
@@ -566,9 +593,10 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                     gpxViewModel?.orsProfile = profile
 
                     if (gpxDisplayState == GpxDisplayState.LOADED_FROM_FILE) {
-                        showGpxDialog {
-                            listener?.parseCalculatedGpx(gpx)
-                        }
+                        showGpxDialog(
+                            action = GPX_DISCARD_ACTION_REPLACE_CALCULATED,
+                            replacementGpx = gpx
+                        )
                     } else {
                         removeGpx()
                         listener?.parseCalculatedGpx(gpx)
@@ -902,23 +930,22 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         }
     }
 
-    private fun showGpxDialog(onConfirmed: (() -> Unit)? = null) {
-        val hostActivity = activity ?: return
-        val builder: AlertDialog.Builder = AlertDialog.Builder(hostActivity, R.style.AlertDialogTheme)
-        builder.setTitle(getString(R.string.gpx))
-            .setMessage(getString(R.string.discard_current_gpx))
-            .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _: Int ->
-                removeGpx()
-                onConfirmed?.invoke()
-                dialog.dismiss()
-            }
-            .setNegativeButton(
-                android.R.string.cancel
-            ) { dialog: DialogInterface, _: Int -> dialog.cancel() }
-            .setIcon(R.drawable.ic_alert)
-        val dialog = builder.create()
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        dialog.show()
+    private fun showGpxDialog(
+        action: String,
+        replacementGpx: String? = null
+    ) {
+        val result = bundleOf(GPX_DISCARD_ACTION_KEY to action)
+        replacementGpx?.let { result.putString(GPX_REPLACEMENT_KEY, it) }
+
+        ConfirmationDialogFragment.newInstance(
+            titleRes = R.string.gpx,
+            messageRes = R.string.discard_current_gpx,
+            iconRes = R.drawable.ic_alert,
+            confirmButtonRes = android.R.string.ok,
+            dismissButtonRes = android.R.string.cancel,
+            requestKey = GPX_DISCARD_REQUEST_KEY,
+            result = result
+        ).show(childFragmentManager, GPX_DISCARD_DIALOG_TAG)
     }
 
     private fun zoomToBounds(box: BoundingBox) {
@@ -1020,13 +1047,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         when (itemId) {
             R.id.action_gpx -> {
                 if (gpxDisplayState != GpxDisplayState.IDLE) {
-                    showGpxDialog {
-                        markerViewModel.markers.value?.forEach {
-                            it.routeWaypoint = false
-                        }
-                        listener?.clearGpx()
-                        listener?.selectGpx()
-                    }
+                    showGpxDialog(GPX_DISCARD_ACTION_SELECT_NEW)
                 } else {
                     listener?.selectGpx()
                 }
@@ -1086,12 +1107,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 return true
             }
             R.id.action_gpx_remove -> {
-                showGpxDialog {
-                    markerViewModel.markers.value?.forEach {
-                        it.routeWaypoint = false
-                    }
-                    listener?.clearGpx()
-                }
+                showGpxDialog(GPX_DISCARD_ACTION_REMOVE)
                 return true
             }
             R.id.action_kml_zoom -> {
@@ -1435,6 +1451,13 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
     }
 
     companion object {
+        private const val GPX_DISCARD_REQUEST_KEY = "gpx_discard_request"
+        private const val GPX_DISCARD_DIALOG_TAG = "gpx_discard_dialog"
+        private const val GPX_DISCARD_ACTION_KEY = "gpx_discard_action"
+        private const val GPX_REPLACEMENT_KEY = "gpx_replacement"
+        private const val GPX_DISCARD_ACTION_REPLACE_CALCULATED = "replace_calculated"
+        private const val GPX_DISCARD_ACTION_SELECT_NEW = "select_new"
+        private const val GPX_DISCARD_ACTION_REMOVE = "remove"
         private const val PARAM_LATITUDE = "latitude"
         private const val PARAM_LONGITUDE = "longitude"
         private const val STATE_LATITUDE = "latitude"

--- a/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
@@ -58,7 +58,8 @@ class ConfirmationDialogFragment : DialogFragment() {
                         confirmButton = stringResource(confirmButtonRes),
                         dismissButton = stringResource(dismissButtonRes),
                         onConfirm = {
-                            parentFragmentManager.setFragmentResult(requestKey, bundleOf())
+                            val result = requireArguments().getBundle(ARG_RESULT) ?: bundleOf()
+                            parentFragmentManager.setFragmentResult(requestKey, result)
                             dismiss()
                         },
                         onDismiss = { dismiss() }
@@ -92,6 +93,7 @@ class ConfirmationDialogFragment : DialogFragment() {
         private const val ARG_CONFIRM_BUTTON = "confirm_button"
         private const val ARG_DISMISS_BUTTON = "dismiss_button"
         private const val ARG_REQUEST_KEY = "request_key"
+        private const val ARG_RESULT = "result"
 
         fun newInstance(
             @StringRes titleRes: Int,
@@ -99,7 +101,8 @@ class ConfirmationDialogFragment : DialogFragment() {
             @DrawableRes iconRes: Int,
             @StringRes confirmButtonRes: Int,
             @StringRes dismissButtonRes: Int,
-            requestKey: String
+            requestKey: String,
+            result: Bundle = bundleOf()
         ) = ConfirmationDialogFragment().apply {
             arguments = bundleOf(
                 ARG_TITLE to titleRes,
@@ -107,7 +110,8 @@ class ConfirmationDialogFragment : DialogFragment() {
                 ARG_ICON to iconRes,
                 ARG_CONFIRM_BUTTON to confirmButtonRes,
                 ARG_DISMISS_BUTTON to dismissButtonRes,
-                ARG_REQUEST_KEY to requestKey
+                ARG_REQUEST_KEY to requestKey,
+                ARG_RESULT to result
             )
         }
     }

--- a/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
@@ -1,0 +1,168 @@
+package org.nitri.opentopo.view
+
+import android.app.Dialog
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Window
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import org.nitri.opentopo.ui.theme.OpenTopoTheme
+
+class ConfirmationDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val titleRes = requireArguments().getInt(ARG_TITLE)
+        val messageRes = requireArguments().getInt(ARG_MESSAGE)
+        val iconRes = requireArguments().getInt(ARG_ICON)
+        val confirmButtonRes = requireArguments().getInt(ARG_CONFIRM_BUTTON)
+        val dismissButtonRes = requireArguments().getInt(ARG_DISMISS_BUTTON)
+        val requestKey = requireArguments().getString(ARG_REQUEST_KEY)
+            ?: error("A Fragment Result request key is required")
+
+        val composeView = ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                OpenTopoTheme(dynamicColor = false) {
+                    ConfirmationDialogContent(
+                        title = stringResource(titleRes),
+                        message = stringResource(messageRes),
+                        iconRes = iconRes,
+                        confirmButton = stringResource(confirmButtonRes),
+                        dismissButton = stringResource(dismissButtonRes),
+                        onConfirm = {
+                            parentFragmentManager.setFragmentResult(requestKey, bundleOf())
+                            dismiss()
+                        },
+                        onDismiss = { dismiss() }
+                    )
+                }
+            }
+        }
+
+        composeView.setViewTreeLifecycleOwner(this)
+        composeView.setViewTreeViewModelStoreOwner(this)
+        composeView.setViewTreeSavedStateRegistryOwner(this)
+
+        return Dialog(requireContext()).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setContentView(composeView)
+            window?.setBackgroundDrawable(ColorDrawable(android.graphics.Color.TRANSPARENT))
+            setOnShowListener {
+                window?.decorView?.let { decorView ->
+                    decorView.setViewTreeLifecycleOwner(this@ConfirmationDialogFragment)
+                    decorView.setViewTreeViewModelStoreOwner(this@ConfirmationDialogFragment)
+                    decorView.setViewTreeSavedStateRegistryOwner(this@ConfirmationDialogFragment)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_TITLE = "title"
+        private const val ARG_MESSAGE = "message"
+        private const val ARG_ICON = "icon"
+        private const val ARG_CONFIRM_BUTTON = "confirm_button"
+        private const val ARG_DISMISS_BUTTON = "dismiss_button"
+        private const val ARG_REQUEST_KEY = "request_key"
+
+        fun newInstance(
+            @StringRes titleRes: Int,
+            @StringRes messageRes: Int,
+            @DrawableRes iconRes: Int,
+            @StringRes confirmButtonRes: Int,
+            @StringRes dismissButtonRes: Int,
+            requestKey: String
+        ) = ConfirmationDialogFragment().apply {
+            arguments = bundleOf(
+                ARG_TITLE to titleRes,
+                ARG_MESSAGE to messageRes,
+                ARG_ICON to iconRes,
+                ARG_CONFIRM_BUTTON to confirmButtonRes,
+                ARG_DISMISS_BUTTON to dismissButtonRes,
+                ARG_REQUEST_KEY to requestKey
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfirmationDialogContent(
+    title: String,
+    message: String,
+    @DrawableRes iconRes: Int,
+    confirmButton: String,
+    dismissButton: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.widthIn(min = 280.dp, max = 560.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 6.dp
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = Color.Unspecified
+                )
+                Spacer(Modifier.width(16.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+            }
+            Text(
+                text = message,
+                modifier = Modifier.padding(top = 16.dp),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(dismissButton)
+                }
+                TextButton(onClick = onConfirm) {
+                    Text(confirmButton)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace the AppCompat GPX discard dialog with a reusable Compose confirmation dialog
- use Fragment Results so confirmation actions survive configuration changes
- preserve all three existing flows: replace a calculated route, select another GPX, and remove the current GPX
- retain the current title, message, warning icon, and OK/Cancel actions

## Testing

- CI build requested
- manually verify replacing a loaded GPX, removing it, and replacing it with a calculated ORS route
- verify OK and Cancel in portrait and landscape