### PR TITLE
Migrate marker deletion confirmations to Compose

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
+++ b/app/src/main/java/org/nitri/opentopo/MarkerListActivity.kt
@@ -2,7 +2,6 @@ package org.nitri.opentopo
 
 import android.net.Uri
 import android.os.Bundle
-import android.view.Window
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -56,6 +55,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
@@ -65,6 +65,7 @@ import org.nitri.opentopo.model.MarkerModel
 import org.nitri.opentopo.ui.theme.OpenTopoTheme
 import org.nitri.opentopo.util.GpxMarkerExporter
 import org.nitri.opentopo.util.GpxMarkerImporter
+import org.nitri.opentopo.view.ConfirmationDialogFragment
 import org.nitri.opentopo.view.MarkerEditorDialog
 import org.nitri.opentopo.viewmodel.MarkerViewModel
 import java.util.Locale
@@ -118,6 +119,21 @@ class MarkerListActivity : AppCompatActivity() {
             }
         }
 
+        supportFragmentManager.setFragmentResultListener(
+            DELETE_SELECTED_REQUEST_KEY,
+            this
+        ) { _, result ->
+            val selectedIds = result.getIntArray(RESULT_SELECTED_MARKER_IDS)
+                ?.toSet()
+                .orEmpty()
+            if (selectedIds.isEmpty()) {
+                return@setFragmentResultListener
+            }
+
+            markerViewModel.removeMarkers(selectedIds.toList())
+            AnalyticsProvider.get(this).trackMarkersDeleted(selectedIds.size)
+        }
+
         setContent {
             OpenTopoTheme(dynamicColor = false) {
                 MarkerListScreen(
@@ -146,20 +162,19 @@ class MarkerListActivity : AppCompatActivity() {
     }
 
     private fun showDeleteSelectedConfirmation(selectedIds: Set<Int>) {
-        androidx.appcompat.app.AlertDialog.Builder(this)
-            .setTitle(getString(R.string.confirm_delete))
-            .setMessage(getString(R.string.delete_selected_markers_message, selectedIds.size))
-            .setPositiveButton(R.string.delete) { _, _ ->
-                val deletedCount = selectedIds.size
-                markerViewModel.removeMarkers(selectedIds.toList())
-                AnalyticsProvider.get(this@MarkerListActivity).trackMarkersDeleted(deletedCount)
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .create()
-            .also {
-                it.requestWindowFeature(Window.FEATURE_NO_TITLE)
-                it.show()
-            }
+        if (supportFragmentManager.findFragmentByTag(DELETE_SELECTED_DIALOG_TAG) != null) {
+            return
+        }
+
+        ConfirmationDialogFragment.newInstance(
+            titleRes = R.string.confirm_delete,
+            message = getString(R.string.delete_selected_markers_message, selectedIds.size),
+            iconRes = null,
+            confirmButtonRes = R.string.delete,
+            dismissButtonRes = R.string.cancel,
+            requestKey = DELETE_SELECTED_REQUEST_KEY,
+            result = bundleOf(RESULT_SELECTED_MARKER_IDS to selectedIds.toIntArray())
+        ).show(supportFragmentManager, DELETE_SELECTED_DIALOG_TAG)
     }
 
     private fun exportSelectedMarkers(uri: Uri, selectedIds: Set<Int>) {
@@ -228,6 +243,9 @@ class MarkerListActivity : AppCompatActivity() {
 
     companion object {
         private const val DEFAULT_EXPORT_FILENAME = "opentopomap-markers.gpx"
+        private const val DELETE_SELECTED_REQUEST_KEY = "delete_selected_markers"
+        private const val DELETE_SELECTED_DIALOG_TAG = "DeleteSelectedMarkersConfirmation"
+        private const val RESULT_SELECTED_MARKER_IDS = "selected_marker_ids"
     }
 }
 

--- a/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/ConfirmationDialogFragment.kt
@@ -39,12 +39,14 @@ import org.nitri.opentopo.ui.theme.OpenTopoTheme
 class ConfirmationDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val titleRes = requireArguments().getInt(ARG_TITLE)
-        val messageRes = requireArguments().getInt(ARG_MESSAGE)
-        val iconRes = requireArguments().getInt(ARG_ICON)
-        val confirmButtonRes = requireArguments().getInt(ARG_CONFIRM_BUTTON)
-        val dismissButtonRes = requireArguments().getInt(ARG_DISMISS_BUTTON)
-        val requestKey = requireArguments().getString(ARG_REQUEST_KEY)
+        val arguments = requireArguments()
+        val titleRes = arguments.getInt(ARG_TITLE)
+        val messageRes = arguments.getInt(ARG_MESSAGE)
+        val messageText = arguments.getString(ARG_MESSAGE_TEXT)
+        val iconRes = arguments.getInt(ARG_ICON).takeIf { it != 0 }
+        val confirmButtonRes = arguments.getInt(ARG_CONFIRM_BUTTON)
+        val dismissButtonRes = arguments.getInt(ARG_DISMISS_BUTTON)
+        val requestKey = arguments.getString(ARG_REQUEST_KEY)
             ?: error("A Fragment Result request key is required")
 
         val composeView = ComposeView(requireContext()).apply {
@@ -53,7 +55,7 @@ class ConfirmationDialogFragment : DialogFragment() {
                 OpenTopoTheme(dynamicColor = false) {
                     ConfirmationDialogContent(
                         title = stringResource(titleRes),
-                        message = stringResource(messageRes),
+                        message = messageText ?: stringResource(messageRes),
                         iconRes = iconRes,
                         confirmButton = stringResource(confirmButtonRes),
                         dismissButton = stringResource(dismissButtonRes),
@@ -89,6 +91,7 @@ class ConfirmationDialogFragment : DialogFragment() {
     companion object {
         private const val ARG_TITLE = "title"
         private const val ARG_MESSAGE = "message"
+        private const val ARG_MESSAGE_TEXT = "message_text"
         private const val ARG_ICON = "icon"
         private const val ARG_CONFIRM_BUTTON = "confirm_button"
         private const val ARG_DISMISS_BUTTON = "dismiss_button"
@@ -98,16 +101,56 @@ class ConfirmationDialogFragment : DialogFragment() {
         fun newInstance(
             @StringRes titleRes: Int,
             @StringRes messageRes: Int,
-            @DrawableRes iconRes: Int,
+            @DrawableRes iconRes: Int?,
             @StringRes confirmButtonRes: Int,
             @StringRes dismissButtonRes: Int,
             requestKey: String,
             result: Bundle = bundleOf()
+        ) = createInstance(
+            titleRes = titleRes,
+            messageRes = messageRes,
+            messageText = null,
+            iconRes = iconRes,
+            confirmButtonRes = confirmButtonRes,
+            dismissButtonRes = dismissButtonRes,
+            requestKey = requestKey,
+            result = result
+        )
+
+        fun newInstance(
+            @StringRes titleRes: Int,
+            message: String,
+            @DrawableRes iconRes: Int?,
+            @StringRes confirmButtonRes: Int,
+            @StringRes dismissButtonRes: Int,
+            requestKey: String,
+            result: Bundle = bundleOf()
+        ) = createInstance(
+            titleRes = titleRes,
+            messageRes = 0,
+            messageText = message,
+            iconRes = iconRes,
+            confirmButtonRes = confirmButtonRes,
+            dismissButtonRes = dismissButtonRes,
+            requestKey = requestKey,
+            result = result
+        )
+
+        private fun createInstance(
+            @StringRes titleRes: Int,
+            @StringRes messageRes: Int,
+            messageText: String?,
+            @DrawableRes iconRes: Int?,
+            @StringRes confirmButtonRes: Int,
+            @StringRes dismissButtonRes: Int,
+            requestKey: String,
+            result: Bundle
         ) = ConfirmationDialogFragment().apply {
             arguments = bundleOf(
                 ARG_TITLE to titleRes,
                 ARG_MESSAGE to messageRes,
-                ARG_ICON to iconRes,
+                ARG_MESSAGE_TEXT to messageText,
+                ARG_ICON to (iconRes ?: 0),
                 ARG_CONFIRM_BUTTON to confirmButtonRes,
                 ARG_DISMISS_BUTTON to dismissButtonRes,
                 ARG_REQUEST_KEY to requestKey,
@@ -121,7 +164,7 @@ class ConfirmationDialogFragment : DialogFragment() {
 private fun ConfirmationDialogContent(
     title: String,
     message: String,
-    @DrawableRes iconRes: Int,
+    @DrawableRes iconRes: Int?,
     confirmButton: String,
     dismissButton: String,
     onConfirm: () -> Unit,
@@ -134,16 +177,21 @@ private fun ConfirmationDialogContent(
         tonalElevation = 6.dp
     ) {
         Column(modifier = Modifier.padding(24.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(iconRes),
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = Color.Unspecified
-                )
-                Spacer(Modifier.width(16.dp))
+            if (iconRes != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(iconRes),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = Color.Unspecified
+                    )
+                    Spacer(Modifier.width(16.dp))
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                }
+            } else {
                 Text(
                     text = title,
                     style = MaterialTheme.typography.headlineSmall

--- a/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
+++ b/app/src/main/java/org/nitri/opentopo/view/MarkerEditorDialog.kt
@@ -144,32 +144,30 @@ class MarkerEditorDialog : DialogFragment() {
     }
 
     private fun showDeleteConfirmation(markerId: Int) {
-        // Selecting the editor's neutral button dismisses its AlertDialog, which can detach this
-        // DialogFragment before the confirmation dialog's button callback runs.
+        // Selecting the editor's neutral button dismisses its AlertDialog, so use the
+        // activity's FragmentManager for the follow-up confirmation and its result.
         val fragmentManager = parentFragmentManager
+        if (fragmentManager.findFragmentByTag(DELETE_CONFIRMATION_TAG) != null) {
+            return
+        }
 
-        AlertDialog.Builder(requireContext())
-            .setTitle(R.string.confirm_delete)
-            .setMessage(R.string.prompt_confirm_delete)
-            .setPositiveButton(R.string.delete) { _, _ ->
-                fragmentManager.setFragmentResult(
-                    RESULT_REQUEST_KEY,
-                    Bundle().apply {
-                        putString(RESULT_ACTION, RESULT_ACTION_DELETE)
-                        putInt(RESULT_MARKER_ID, markerId)
-                    }
-                )
+        ConfirmationDialogFragment.newInstance(
+            titleRes = R.string.confirm_delete,
+            messageRes = R.string.prompt_confirm_delete,
+            iconRes = null,
+            confirmButtonRes = R.string.delete,
+            dismissButtonRes = R.string.cancel,
+            requestKey = RESULT_REQUEST_KEY,
+            result = Bundle().apply {
+                putString(RESULT_ACTION, RESULT_ACTION_DELETE)
+                putInt(RESULT_MARKER_ID, markerId)
             }
-            .setNegativeButton(R.string.cancel, null)
-            .create()
-            .also {
-                it.requestWindowFeature(Window.FEATURE_NO_TITLE)
-                it.show()
-            }
+        ).show(fragmentManager, DELETE_CONFIRMATION_TAG)
     }
 
     companion object {
         const val TAG = "MarkerEditorDialog"
+        private const val DELETE_CONFIRMATION_TAG = "MarkerDeleteConfirmation"
 
         private const val ARG_ID = "arg_id"
         private const val ARG_NAME = "arg_name"


### PR DESCRIPTION
## Summary

- migrate the single-marker delete confirmation from `MarkerEditorDialog`
- migrate the selected-markers delete confirmation from `MarkerListActivity`
- reuse `ConfirmationDialogFragment` for both flows
- support confirmation dialogs without an icon and with a preformatted message
- carry marker IDs through Fragment Results so the intended deletion survives configuration changes

## Testing

- CI build requested
- delete one marker through the marker editor
- cancel deletion through the marker editor
- select and delete multiple markers
- cancel deletion of selected markers
- rotate while either confirmation is open, then confirm or cancel