### PR TITLE
Clear route after final waypoint is removed

### DIFF
--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -542,9 +542,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                     calculateRoute()
                 }
             })
-            if (markerViewModel.hasRoutePoints()) {
-                calculateRoute()
-            }
+            calculateRoute()
         }
     }
 
@@ -557,9 +555,7 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
         }
 
         if (markers.isEmpty()) {
-            if (gpxDisplayState == GpxDisplayState.CALCULATED) {
-                listener?.clearGpx()
-            }
+            clearCalculatedRoute()
             return
         }
 
@@ -628,6 +624,15 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
             }
             )
         }
+    }
+
+    private fun clearCalculatedRoute() {
+        if (gpxDisplayState != GpxDisplayState.CALCULATED) {
+            return
+        }
+
+        removeGpx()
+        listener?.clearGpx()
     }
 
     private fun centerOnFirstFix() {

--- a/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
+++ b/app/src/main/java/org/nitri/opentopo/overlay/OverlayHelper.kt
@@ -247,6 +247,7 @@ class OverlayHelper(
                 wayPointOverlay = null
             }
         }
+        mMapView?.invalidate()
     }
 
     fun setKml(kmlDocument: KmlDocument) {


### PR DESCRIPTION
## Summary

Fix a stale calculated route remaining on the map after its final marker waypoint is removed or deleted.

## Root cause

Two related paths were incomplete:

- Removing waypoint status from the final marker called `calculateRoute()`, but the zero-waypoint branch cleared only the activity-held GPX data. It did not remove the map overlay or reset `GpxDisplayState`.
- Deleting the final waypoint marker updated the observed marker list, but route reconciliation was conditional on at least one waypoint still existing. Consequently, the zero-waypoint transition was skipped.

## Changes

- Reconcile route state after every marker-list update.
- Centralize clearing of a calculated route when no marker waypoints remain.
- Clear the map overlay, reset calculated-route display state, and clear retained GPX data together.
- Invalidate the map after GPX overlays are removed so the visual change is immediate.
- Preserve a GPX loaded from a file; only `GpxDisplayState.CALCULATED` is cleared automatically.

## Verification

Please verify on a device:

1. Calculate a route to marker A.
2. Add marker B as a route waypoint.
3. Remove A from the route; the route should recalculate to B.
4. Remove B from the route; the route and route-point overlays should disappear immediately.
5. Repeat, but delete B while it is the final route waypoint; the route should disappear.
6. Load a GPX file, then add/remove an ordinary marker; the loaded GPX must remain visible.

Automated tests were not run in this connector-only change.