### PR TITLE
Clear persisted waypoints when removing GPX

### DIFF
--- a/app/src/androidTest/java/org/nitri/opentopo/da/MarkerDaoInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/nitri/opentopo/da/MarkerDaoInstrumentedTest.kt
@@ -37,6 +37,33 @@ class MarkerDaoInstrumentedTest {
         assertTrue(dao.getAllMarkersNow().isEmpty())
     }
 
+    @Test fun clearRouteWaypoints_preservesMarkersAndClearsOnlyWaypointFlags() = runBlocking {
+        dao.insertMarkers(listOf(
+            MarkerModel(
+                seq = 1,
+                latitude = 1.0,
+                longitude = 1.0,
+                name = "waypoint",
+                description = "",
+                routeWaypoint = true
+            ),
+            MarkerModel(
+                seq = 2,
+                latitude = 2.0,
+                longitude = 2.0,
+                name = "ordinary",
+                description = "",
+                routeWaypoint = false
+            )
+        ))
+
+        dao.clearRouteWaypoints()
+
+        val markers = dao.getAllMarkersNow()
+        assertEquals(2, markers.size)
+        assertTrue(markers.none { it.routeWaypoint })
+    }
+
     @Test fun deleteMarkersByIds_removesMultiple() = runBlocking {
         dao.insertMarkers(listOf(
             MarkerModel(seq = 1, latitude = 1.0, longitude = 1.0, name = "a", description = ""),

--- a/app/src/main/java/org/nitri/opentopo/MapFragment.kt
+++ b/app/src/main/java/org/nitri/opentopo/MapFragment.kt
@@ -188,17 +188,13 @@ class MapFragment : Fragment(), LocationListener, PopupMenu.OnMenuItemClickListe
                 }
                 GPX_DISCARD_ACTION_SELECT_NEW -> {
                     removeGpx()
-                    markerViewModel.markers.value?.forEach {
-                        it.routeWaypoint = false
-                    }
+                    markerViewModel.clearRouteWaypoints()
                     listener?.clearGpx()
                     listener?.selectGpx()
                 }
                 GPX_DISCARD_ACTION_REMOVE -> {
                     removeGpx()
-                    markerViewModel.markers.value?.forEach {
-                        it.routeWaypoint = false
-                    }
+                    markerViewModel.clearRouteWaypoints()
                     listener?.clearGpx()
                 }
             }

--- a/app/src/main/java/org/nitri/opentopo/da/MarkerDao.kt
+++ b/app/src/main/java/org/nitri/opentopo/da/MarkerDao.kt
@@ -24,6 +24,9 @@ interface MarkerDao {
     @Update
     suspend fun updateMarker(marker: MarkerModel)
 
+    @Query("UPDATE MarkerModel SET routeWaypoint = 0 WHERE routeWaypoint = 1")
+    suspend fun clearRouteWaypoints()
+
     @Query("DELETE FROM MarkerModel WHERE id = :markerId")
     suspend fun deleteMarkerById(markerId: Int)
 

--- a/app/src/main/java/org/nitri/opentopo/viewmodel/MarkerViewModel.kt
+++ b/app/src/main/java/org/nitri/opentopo/viewmodel/MarkerViewModel.kt
@@ -41,6 +41,10 @@ class MarkerViewModel(application: Application) : AndroidViewModel(application) 
         db.markerDao().updateMarker(marker)
     }
 
+    fun clearRouteWaypoints() = viewModelScope.launch {
+        db.markerDao().clearRouteWaypoints()
+    }
+
     fun hasRoutePoints(): Boolean {
         return markers.value?.any { it.routeWaypoint } ?: false
     }


### PR DESCRIPTION
## Summary

Ensure **Remove GPX** also clears the persisted route-waypoint flags from all markers.

Without this, the route overlay disappears but Room still stores the old markers with `routeWaypoint = true`. Adding one waypoint for a new route then causes all old waypoints to be included again.

## Changes

- Add one atomic Room update that clears `routeWaypoint` only for markers currently marked as waypoints.
- Expose that operation through `MarkerViewModel`.
- Use the persisted reset for both GPX removal flows:
  - **Remove GPX**
  - selecting a new GPX after discarding the current one
- Add an instrumentation regression test confirming:
  - all markers remain in the database;
  - all route-waypoint flags are cleared;
  - ordinary markers remain unaffected.

## Device verification

1. Create a calculated route with at least two marker waypoints.
2. Select **Remove GPX** and confirm.
3. Add one marker as the first waypoint of a new route.
4. Confirm the new calculation includes only that marker, not the previous route’s waypoints.
5. Restart the app and repeat step 3 to verify the cleared state was persisted.

This is a follow-up to #96.